### PR TITLE
Remove redundant comment

### DIFF
--- a/python scripts/bc_extract.py
+++ b/python scripts/bc_extract.py
@@ -1,10 +1,8 @@
 #! /usr/bin python3
 
+
 def main():
 
-    #
-    # Imports & globals
-    #
     global args
     import BLR_functions as BLR, sys
 


### PR DESCRIPTION
Obvious comments are unnecessary. You can assume that the reader already
knows Python, so it’s not necessary here to explain that you’re doing an
import.

Writing "I’m importing things here" does not add any information and even
takes away screen space that could be used to display actual
code. Also, there is always a risk that a comment is not updated when the
code changes, thus getting out of sync.

See also the section about comments in the Python style guide (PEP 8):
https://www.python.org/dev/peps/pep-0008/#comments