### PR TITLE
No need to derive from object explicitly

### DIFF
--- a/python scripts/BLR_functions.py
+++ b/python scripts/BLR_functions.py
@@ -44,7 +44,7 @@ def report_progress(string):
     """
     sys.stderr.write(script_name.upper() + ':\t' + time.strftime("%a, %d %b %Y %H:%M:%S", time.localtime()) + '\t' + string + '\n')
 
-class ProgressReporter(object):
+class ProgressReporter:
     """
     Progress reporter object, writes updates to std err for every <report_step> iteration. Used for iterations of unknown
     lengths.
@@ -77,7 +77,7 @@ class ProgressReporter(object):
             report_progress(self.name + '\t' + "{:,}".format(self.position))
             self.next_limit += self.report_step
 
-class ProgressBar(object):
+class ProgressBar:
     """
     Progress reporter object, writes updates to std err in for of a progress bar. Used for iterations of known lenghts.
 
@@ -138,7 +138,7 @@ class ProgressBar(object):
         """
         sys.stderr.write('\n')
 
-class FileReader(object):
+class FileReader:
     """
     Reads input files as generator, handles gzip.
     """
@@ -237,7 +237,7 @@ class FileReader(object):
         if self.filehandle2:
             self.openfile2.close()
 
-class FastqRead(object):
+class FastqRead:
     """
     Stores read as instance.
     """

--- a/python scripts/bc_extract.py
+++ b/python scripts/bc_extract.py
@@ -51,7 +51,7 @@ def main():
     generator.close()
     BLR.report_progress('Finished')
 
-class readArgs(object):
+class readArgs:
     """
     Reads arguments and handles basic error handling like python version control etc.
     """

--- a/python scripts/cdhit_prep.py
+++ b/python scripts/cdhit_prep.py
@@ -106,7 +106,7 @@ def reduceComplexity(bc_dict):
 
     return index_dict, not_ATGC_index
 
-class readArgs(object):
+class readArgs:
     """
     Reads arguments and handles basic error handling like python version control etc.
     """

--- a/python scripts/cluster_rmdup.py
+++ b/python scripts/cluster_rmdup.py
@@ -399,7 +399,7 @@ def report_matches(current_match_dict, merge_dict, chromosome):#, duplicate_posi
 
     return merge_dict
 
-class OverlapValues(object):
+class OverlapValues:
     """
     bc_id^2 matrix tracking overalap values.
     """
@@ -455,7 +455,7 @@ class OverlapValues(object):
 
         return value_vector_dict
 
-class BarcodeDuplicates(object):
+class BarcodeDuplicates:
     """
     Tracks barcode ID:s which have readpairs ovelapping with others.
     """
@@ -533,7 +533,7 @@ class BarcodeDuplicates(object):
         else:
             self.translation_dict[bc_id] = min_id
 
-class readArgs(object):
+class readArgs:
     """ Reads arguments and handles basic error handling like python version control etc."""
 
     def __init__(self):
@@ -590,7 +590,7 @@ class readArgs(object):
             else:
                 sys.stderr.write('\nForcing run. This might yield inaccurate results.\n')
 
-class Summary(object):
+class Summary:
     """ Summarizes chunks"""
 
     def __init__(self):

--- a/python scripts/filter_clusters.py
+++ b/python scripts/filter_clusters.py
@@ -165,7 +165,7 @@ def fetch_and_format(read):
 
     return BC_id, read_start, read_stop
 
-class Molecules(object):
+class Molecules:
     """
     Tmp storage for molecules which might still get more reads assigned to them. Basically a dict with customised functions.
     """
@@ -214,7 +214,7 @@ class Molecules(object):
             summary.reportMolecule(name=BC_id, molecule=self.dictionary[BC_id])
             del self.dictionary[BC_id]
 
-class readArgs(object):
+class readArgs:
     """
     Reads arguments and handles basic error handling like python version control etc.
     """
@@ -280,7 +280,7 @@ class readArgs(object):
             else:
                 sys.stderr.write('\nForcing run. This might yield inaccurate results.\n')
 
-class Summary(object):
+class Summary:
 
     def __init__(self):
 

--- a/python scripts/tag_bam.py
+++ b/python scripts/tag_bam.py
@@ -80,7 +80,7 @@ def ProcessClusters(openInfile):
 
     return(cluster_dict)
 
-class readArgs(object):
+class readArgs:
     """ Reads arguments and handles basic error handling like python version control etc."""
 
     def __init__(self):


### PR DESCRIPTION
In Python 3, every class implicitly derives from object.

In Python 2, there was a difference: Leaving out `(object)` would give you an
old-style class and including it a new-style class. Python 3 only has
new-style classes.