### PR TITLE
Test that the final generated BAM is as expected

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,3 +4,5 @@ set -xeuo pipefail
 ( cd testdata && bowtie2-build chr1mini.fasta chr1mini > /dev/null )
 
 bash BLR_automation.sh testdata/reads.1.fastq.gz testdata/reads.2.fastq.gz outdir
+m=$(samtools view outdir/reads.1.fastq.sort.tag.rmdup.x2.filt.bam | md5sum | cut -f1 -d" ")
+test $m == 51788863e44c1a43f8da7287b1cb2867


### PR DESCRIPTION
I have hard-coded the MD5 sum of the SAM (without headers) for now. This should be enough to see whether the pipeline still works as expected, which is important since the next changes will be refactoring the pipeline.