### PR TITLE
Replace the first pipeline step with a Snakefile

### DIFF
--- a/BLR_automation.sh
+++ b/BLR_automation.sh
@@ -213,14 +213,11 @@ then
     printf '\n1. Demultiplexing\n'
     printf "`date`"'\t1st adaptor removal\n'
 
-    # Trim away E handle on R1 5'. Also removes reads shorter than 85 bp.
-    cutadapt -g ^CAGTTGATCATCAGCAGGTAATCTGG \
-        -j $processors \
-        -o $file_name".h1.fastq.gz" \
-        -p $file_name2".h1.fastq.gz" \
-        $ARG1 \
-        $ARG2 \
-        --discard-untrimmed -e 0.2 -m 65 > $trim_logfile # Tosses reads shorter than len(e+bc+handle+TES)
+    ln -sr $ARG1 $path/reads.1.fastq.gz
+    ln -sr $ARG2 $path/reads.2.fastq.gz
+    snakemake $path/trimmed-a.1.fastq.gz $path/trimmed-a.2.fastq.gz
+    ln -sr $path/trimmed-a.1.fastq.gz $file_name".h1.fastq.gz"
+    ln -sr $path/trimmed-a.2.fastq.gz $file_name2".h1.fastq.gz"
 
     printf "`date`"'\t1st adaptor removal done\n'
     printf "`date`"'\tBarcode extraction\n'

--- a/Snakefile
+++ b/Snakefile
@@ -1,0 +1,22 @@
+# kate: syntax Python;
+rule:
+    "Trim away E handle on R1 5'. Also removes reads shorter than 85 bp."
+    output:
+        r1_fastq="{dir}/trimmed-a.1.fastq.gz",
+        r2_fastq="{dir}/trimmed-a.2.fastq.gz"
+    input:
+        r1_fastq="{dir}/reads.1.fastq.gz",
+        r2_fastq="{dir}/reads.2.fastq.gz"
+    log: "{dir}/trimmed-a.log"
+    threads: 20
+    shell:
+        "cutadapt -g ^CAGTTGATCATCAGCAGGTAATCTGG"
+        " -j {threads}"
+        " --discard-untrimmed"
+        " -e 0.2"
+        " -m 65"
+        " -o {output.r1_fastq}"
+        " -p {output.r2_fastq}"
+        " {input.r1_fastq}"
+        " {input.r2_fastq}"
+        " | tee {log}"

--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,33 @@
-# Dependencies: python=3.6 cutadapt bowtie2 pysam picard=2.10 cd-hit
+# Dependencies: python=3.6 cutadapt bowtie2 pysam picard=2.10 cd-hit snakemake-minimal
 channels:
-  - defaults
-  - bioconda
   - conda-forge
+  - bioconda
+  - defaults
 dependencies:
+  - appdirs=1.4.3=py_1
+  - asn1crypto=0.24.0=py36_1003
+  - attrs=19.1.0=py_0
   - bcftools=1.9=ha228f0b_4
   - bowtie2=2.3.5=py36he860b03_0
   - bz2file=0.98=py36_1
   - bzip2=1.0.6=h14c3975_5
-  - ca-certificates=2019.1.23=0
+  - ca-certificates=2019.3.9=hecc5488_0
   - cd-hit=4.8.1=hdbcaa40_2
   - certifi=2019.3.9=py36_0
+  - cffi=1.12.3=py36h8022711_0
+  - chardet=3.0.4=py36_1003
+  - configargparse=0.13.0=py_1
+  - cryptography=2.7=py36h72c5cf5_0
   - curl=7.64.1=hbc83047_0
   - cutadapt=2.3=py36h14c3975_0
+  - datrie=0.7.1=py36h14c3975_0
   - dnaio=0.3=py36h14c3975_1
+  - docutils=0.14=py36_1001
+  - gitdb2=2.0.5=py_0
+  - gitpython=2.1.11=py_0
   - htslib=1.9=ha228f0b_7
+  - idna=2.8=py36_1000
+  - jsonschema=3.0.1=py36_0
   - krb5=1.16.1=h173b8e3_7
   - libcurl=7.64.1=h20c2e04_0
   - libdeflate=1.0=h14c3975_1
@@ -27,20 +40,34 @@ dependencies:
   - ncurses=6.1=he6710b0_1
   - openjdk=8.0.152=h46b5887_1
   - openmp=8.0.0=0
-  - openssl=1.1.1c=h7b6447c_1
+  - openssl=1.1.1b=h14c3975_1
   - perl=5.26.2=h14c3975_0
   - picard=2.10.6=py36_0
   - pigz=2.4=h84994c4_0
   - pip=19.1.1=py36_0
+  - psutil=5.6.2=py36h516909a_0
+  - pycparser=2.19=py36_1
+  - pyopenssl=19.0.0=py36_0
+  - pyrsistent=0.15.2=py36h516909a_0
   - pysam=0.15.2=py36h4b7d16d_3
+  - pysocks=1.7.0=py36_0
   - python=3.6.8=h0371630_0
+  - pyyaml=5.1=py36h14c3975_0
+  - ratelimiter=1.2.0=py36_1000
   - readline=7.0=h7b6447c_5
+  - requests=2.22.0=py36_0
   - samtools=1.9=h8571acd_11
   - setuptools=41.0.1=py36_0
+  - six=1.12.0=py36_1000
+  - smmap2=2.0.5=py_0
+  - snakemake-minimal=5.5.0=py_0
   - sqlite=3.28.0=h7b6447c_0
   - tbb=2019.7=hc9558a2_0
   - tk=8.6.8=hbc83047_0
+  - urllib3=1.24.3=py36_0
   - wheel=0.33.4=py36_0
+  - wrapt=1.11.1=py36h516909a_0
   - xopen=0.6.0=py_0
   - xz=5.2.4=h14c3975_4
+  - yaml=0.1.7=h14c3975_1001
   - zlib=1.2.11=h7b6447c_3


### PR DESCRIPTION
This adds a Snakefile that contains a rule for adapter trimming, replacing the first pipeline step.

The pipeline script itself is modified to call `snakemake`. The plan is of course that the the pipeline script itself disappears, but I would like to have a working (testable) version of the pipeline with each commit, which is why this commit adds some extra (somewhat hackish) code that will be deleted later.

The advantage of using a Snakefile will appear only later.