### PR TITLE
Remove pythonversion

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2,8 +2,8 @@
 rule trim_r1_handle:
     "Trim away E handle on R1 5'. Also removes reads shorter than 85 bp."
     output:
-        r1_fastq=temp("{dir}/trimmed-a.1.fastq.gz"),
-        r2_fastq=temp("{dir}/trimmed-a.2.fastq.gz")
+        r1_fastq="{dir}/trimmed-a.1.fastq.gz",
+        r2_fastq="{dir}/trimmed-a.2.fastq.gz"
     input:
         r1_fastq="{dir}/reads.1.fastq.gz",
         r2_fastq="{dir}/reads.2.fastq.gz"

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -26,9 +26,7 @@ def main() -> int:
     for _, module_name, _ in modules:
         module = importlib.import_module("." + module_name, cli_package.__name__)
         help = module.__doc__.strip().split("\n", maxsplit=1)[0]
-        subparser = subparsers.add_parser(
-            module_name, help=help, description=module.__doc__
-        )
+        subparser = subparsers.add_parser(module_name, help=help, description=module.__doc__)
         subparser.set_defaults(module=module)
         module.add_arguments(subparser)
 

--- a/src/blr/cli/cdhitprep.py
+++ b/src/blr/cli/cdhitprep.py
@@ -111,9 +111,6 @@ def add_arguments(parser):
 
     parser.add_argument("-f", "--filter", type=int, default=1,
                         help="Filter file for minimum amount of read pairs. DEFAULT: 1")
-    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not running python 3. "
-                                                                       "Not recommended due to different function "
-                                                                       "names in python 2 and 3.")
     parser.add_argument("-i", "--index", type=int, help="Divide BC sequences into descrete files due to their (-i) "
                                                         "first bases. DEFAULT: None")
     parser.add_argument("-s", "--space_separation", action="store_true", help='If BC is separated by <space> ( ) '

--- a/src/blr/cli/cdhitprep.py
+++ b/src/blr/cli/cdhitprep.py
@@ -14,9 +14,6 @@ logger = logging.getLogger(__name__)
 def main(args):
     """Takes a fastq file barcode sequences in the header and writes a barcode fasta file with only unique entries. """
 
-    # Check python3 is being run
-    if not BLR.pythonVersion(args.force_run): sys.exit()
-
     #
     # Filtering
     #

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -584,9 +584,7 @@ def add_arguments(parser):
     parser.add_argument("input_tagged_bam", help=".bam file tagged with RG tags and duplicates marked (not taking "
                                                  "cluster id into account).")
     parser.add_argument("output_bam", help=".bam file without cluster duplicates")
-    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not running python 3. "
-                                                                       "Not recommended due to different function "
-                                                                       "names in python 2 and 3.")
+    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not no barcode if found.")
     parser.add_argument("-t", "--threshold", metavar="<INTEGER>", type=int, default=0, help="Threshold for how many additional overlaps "
                                                                         "(other than four exact positions from two "
                                                                         "readpairs) is needed for mergin two barcode "

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -584,7 +584,8 @@ def add_arguments(parser):
     parser.add_argument("input_tagged_bam", help=".bam file tagged with RG tags and duplicates marked (not taking "
                                                  "cluster id into account).")
     parser.add_argument("output_bam", help=".bam file without cluster duplicates")
-    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not no barcode if found.")
+    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if barcode tags are not "
+                                                                       "found for all reads")
     parser.add_argument("-t", "--threshold", metavar="<INTEGER>", type=int, default=0, help="Threshold for how many additional overlaps "
                                                                         "(other than four exact positions from two "
                                                                         "readpairs) is needed for mergin two barcode "

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -349,9 +349,6 @@ def add_arguments(parser):
                                               ".reads_per_molecule, .molecule_per_barcode and .molecule_lengths). "
                                               "Will also write a .everything file containing rows (equivalent to "
                                               "molecules) with all the information from the other files.")
-    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not running python 3. "
-                                                                       "Not recommended due to different function "
-                                                                       "names in python 2 and 3. DEFAULT: False")
     parser.add_argument("-t","--threshold", metavar='<INTEGER>', type=int, default=4, help="Threshold for how many reads are required for including given molecule in statistics (except_reads_per_molecule). DEFAULT: 4")
     parser.add_argument("-w", "--window", metavar='<INTEGER>', type=int, default=30000, help="Window size cutoff for maximum distance "
                                                                               "in between two reads in one molecule. "

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -72,12 +72,10 @@ def process_clusters(openInfile, skip_nonclust):
 
     return(cluster_dict)
 
+
 def add_arguments(parser):
     parser.add_argument("input_mapped_bam", help=".bam file with mapped reads which is to be tagged with barcode id:s.")
     parser.add_argument("input_clstr", help=".clstr file from cdhit clustering.")
     parser.add_argument("output_tagged_bam", help=".bam file with barcode cluster id in the bc tag.")
-    parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not running python 3. "
-                                                                       "Not recommended due to different function "
-                                                                       "names in python 2 and 3.")
     parser.add_argument("-s", "--skip_nonclust", action="store_true", help="Does not give cluster ID:s to clusters "
                                                                            "made out by only one sequence.")

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -16,30 +16,6 @@ script_name = sys.argv[0].split('/')[-1].split('.')[0]
 # All functions are described in detail in the function specific documentation with examples given in the main function,
 # including how to use the arguments.
 
-def pythonVersion(force_run):
-    """
-    Error handling - Checks if python 3 is being run and returns bool (True/False)
-    :param force_run: bool (True/False). Override python 3 requirement
-    :return: bool (True/False)
-    """
-
-    #
-    # Version control
-    #
-    if sys.version_info.major == 3:
-        python3 = True
-    else:
-        logger.warning(f'You are running python {sys.version_info.major}, this script is written for python 3.')
-        if not force_run:
-            logger.warning(f'You are running python {sys.version_info.major}, this script is written for python 3.')
-            logger.warning('Aborting analysis. Use -F (--Force) to run anyway.')
-            python3 = False
-        else:
-            logger.exception('Forcing run. This might yield inaccurate results.')
-            python3 = True
-
-    return python3
-
 def report_progress(string):
     """
     Progress report function, writes string (<time_stamp> <tab> <string> <newline>) to std err.


### PR DESCRIPTION
Remove function pythonversion from utils.py. This was previously used to confirm that python3 was used to run the script but is no longer relevant as this is now specified within in the setup. Also removed force_run argument from multiple script which was used as an override for the version-check. 