### PR TITLE
Filtercluster rewrite

### DIFF
--- a/BLR_automation.sh
+++ b/BLR_automation.sh
@@ -444,7 +444,7 @@ then
     # Cluster filtering
     (blr filterclusters \
         -M 260 \
-        -ps $path"/cluster_stats/x2.stats" \
+        -s $path"/cluster_stats/x2.stats" \
         $file_name".sort.tag.rmdup.x2.bam" \
         $file_name".sort.tag.rmdup.x2.filt.bam") 2>>$rmdup_logfile
 

--- a/BLR_automation.sh
+++ b/BLR_automation.sh
@@ -443,10 +443,10 @@ then
     mkdir -p $path"/cluster_stats"
     # Cluster filtering
     (blr filterclusters \
-        -f $file_name".sort.tag.rmdup.x2.filt.bam" \
         -M 260 \
+        -ps $path"/cluster_stats/x2.stats" \
         $file_name".sort.tag.rmdup.x2.bam" \
-        $path"/cluster_stats/x2.stats") 2>>$rmdup_logfile
+        $file_name".sort.tag.rmdup.x2.filt.bam") 2>>$rmdup_logfile
 
     printf "`date`"'\tCluster filtering done\n'
     printf "`date`"'\tFastq generation\n'

--- a/environment.yml
+++ b/environment.yml
@@ -71,3 +71,4 @@ dependencies:
   - xz=5.2.4
   - yaml=0.1.7
   - zlib=1.2.11
+  - tqdm=4.32.2

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -245,7 +245,7 @@ class Summary:
         except ZeroDivisionError:
             logger.warning('No reads passing filters found in file.')
 
-    def writeMoleculeStats(self, output_prefix, Max_molecules, allMolecules):
+    def writeMoleculeStats(self, output_prefix, allMolecules):
 
         # Opening all files
         molecules_per_bc_out = open((output_prefix + '.molecules_per_bc'), 'w')

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -59,8 +59,7 @@ def main(args):
     # Stats to output files and stdout
     summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
     if args.print_stats:
-        summary.writeMoleculeStats(output_prefix=args.print_stats, Max_molecules=args.Max_molecules,
-                                 allMolecules=allMolecules)
+        summary.writeMoleculeStats(output_prefix=args.print_stats, allMolecules=allMolecules)
 
 def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary):
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 def main(args):
     summary = Summary()
     molecules = Molecules()
-    prev_chrom = 'chr1'
 
     # Open file, loop over all reads
     logger.info(f'Running analysis with {"{:,}".format(args.window)} bp window size')

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -217,9 +217,6 @@ class Summary:
         self.non_analyzed_reads = int()
         self.number_removed_molecules = int()
 
-        # Stats tracker needed to split bam files into separate according barcode per molecule
-        self.bc_to_numberMolecules = dict()
-
     def printStats(self, barcode_tag, threshold, allMolecules):
 
         # Read stats
@@ -256,9 +253,6 @@ class Summary:
             molecules_per_bc.write(str(number_of_molecules))
             for molecule in (allMolecules.final_dict[barcode]):
                 molecule_stats.write(str(molecule.number_of_reads) + '\t' + str(molecule.length()) + '\t' + barcode + '\t' + str(number_of_molecules) + '\n')
-
-            # Stats tracker needed to split bam files into separate according barcode per molecule
-            self.bc_to_numberMolecules[barcode] = number_of_molecules
 
         # Close files
         for output_file in (molecules_per_bc, molecule_stats):

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -21,13 +21,14 @@ def main(args):
     logger.info('Fetching reads')
     with pysam.AlignmentFile(args.x2_bam, 'rb') as infile:
         allMolecules = build_molecule_dict(pysam_openfile=infile, barcode_tag=args.barcode_tag, window=args.window, min_reads=args.threshold, summary=summary)
+        allMolecules.reportAndRemoveAll()
 
         summary.tot_reads = infile.mapped + infile.unmapped
         summary.unmapped_reads = infile.unmapped
         summary.mapped_reads = infile.mapped
 
+
     # Commit last chr molecules and log stats
-    allMolecules.reportAndRemoveAll()
     summary.non_analyzed_reads = summary.unmapped_reads + summary.non_tagged_reads + summary.overlapping_reads_in_pb
     logger.info('Molecules analyzed')
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -58,8 +58,8 @@ def main(args):
 
     # Stats to output files and stdout
     summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
-    if args.print_stats:
-        summary.writeMoleculeStats(output_prefix=args.print_stats, allMolecules=allMolecules)
+    if args.stats_file:
+        summary.writeMoleculeStats(output_prefix=args.stats_file, allMolecules=allMolecules)
 
 def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary):
 
@@ -240,7 +240,7 @@ class Summary:
 
         try:
             logger.info(f'Reads with barcodes removed:\t{"{:,}".format(self.reads_with_removed_barcode)}\t'
-                        f'({"%.2f" % ((summary.reads_with_removed_barcode/self.tot_reads)*100)}%)')
+                        f'({"%.2f" % ((self.reads_with_removed_barcode/self.tot_reads)*100)}%)')
         except ZeroDivisionError:
             logger.warning('No reads passing filters found in file.')
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -124,7 +124,7 @@ def main(args):
 
         # Stats to output files and stdout
     if args.print_stats:
-        summary.writeResultFiles(output_prefix=args.print_stats, Max_molecules=args.Max_molecules,
+        summary.writeMoleculeStats(output_prefix=args.print_stats, Max_molecules=args.Max_molecules,
                                  allMolecules=allMolecules)
         summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
 
@@ -271,7 +271,7 @@ class Summary:
         logger.info(f'Barcodes removed:\t{len(self.barcode_removal_set)}')
         logger.info(f'Molecules removed:\t{self.number_removed_molecules}')
 
-    def writeResultFiles(self, output_prefix, Max_molecules, allMolecules):
+    def writeMoleculeStats(self, output_prefix, Max_molecules, allMolecules):
 
         # Opening all files
         molecules_per_bc_out = open((output_prefix + '.molecules_per_bc'), 'w')

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -46,12 +46,12 @@ def main(args):
 
             openout.write(read)
 
-    summary.printStats(barcode_tag=args.barcode_tag, molecule_dict=molecule_dict)
+    summary.print_stats(barcode_tag=args.barcode_tag, molecule_dict=molecule_dict)
 
     # Write molecule/barcode file stats
     if args.stats_file:
         logger.info("Writing statistics files")
-        summary.writeMoleculeStats(output_prefix=args.stats_file, molecule_dict=molecule_dict)
+        summary.write_molecule_stats(output_prefix=args.stats_file, molecule_dict=molecule_dict)
 
 def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary):
     """
@@ -78,7 +78,7 @@ def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary)
 
             # Commit molecules between chromosomes
             if not prev_chrom == read.reference_name:
-                allMolecules.reportAndRemoveAll()
+                allMolecules.report_and_remove_all()
                 prev_chrom = read.reference_name
 
             if barcode in allMolecules.cache_dict:
@@ -89,7 +89,7 @@ def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary)
                     if molecule.stop >= read_start and not read.query_name in molecule.read_headers:
                         summary.overlapping_reads_in_pb += 1
                     else:
-                        molecule.addRead(stop=read_stop, read_header=read.query_name)
+                        molecule.add_read(stop=read_stop, read_header=read.query_name)
                         allMolecules.cache_dict[barcode] = molecule
 
                 # Read is not within window => report old and initiate new molecule for that barcode.
@@ -103,7 +103,7 @@ def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary)
                 molecule = Molecule(barcode=barcode, start=read_start, stop=read_stop, read_header=read.query_name)
                 allMolecules.cache_dict[molecule.barcode] = molecule
 
-    allMolecules.reportAndRemoveAll()
+    allMolecules.report_and_remove_all()
 
     return allMolecules.final_dict
 
@@ -162,7 +162,7 @@ class Molecule:
     def length(self):
         return(self.stop - self.start)
 
-    def addRead(self, stop, read_header):
+    def add_read(self, stop, read_header):
         """
         Updates molecule's stop position, number of reads and header name set()
         """
@@ -208,7 +208,7 @@ class AllMolecules:
 
         del self.cache_dict[molecule.barcode]
 
-    def reportAndRemoveAll(self):
+    def report_and_remove_all(self):
         """
         Commit all .cache_dict molecules to .final_dict and empty .cache_dict (provided they meet criterias by report
         function).
@@ -237,7 +237,7 @@ class Summary:
         self.removed_molecules = int()
         self.reads_with_removed_barcode = int()
 
-    def printStats(self, barcode_tag, molecule_dict):
+    def print_stats(self, barcode_tag, molecule_dict):
         """
         Prints stats to terminal
         """
@@ -264,7 +264,7 @@ class Summary:
         except ZeroDivisionError:
             logger.warning("No reads passing filters found in file.")
 
-    def writeMoleculeStats(self, output_prefix, molecule_dict):
+    def write_molecule_stats(self, output_prefix, molecule_dict):
         """
         Writes stats file for molecules and barcode with information like how many reads, barcodes, molecules etc they
         have

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -34,6 +34,7 @@ def main(args):
     # Writes output bam file if wanted
     with pysam.AlignmentFile(args.x2_bam, 'rb') as openin:
         with pysam.AlignmentFile(args.output, 'wb', template=openin) as openout:
+            logging.info("Writing filtered bam file")
             for read in tqdm(openin.fetch(until_eof=True)):
 
                 # If no bc_id, just write it to out
@@ -59,6 +60,7 @@ def main(args):
     # Stats to output files and stdout
     summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
     if args.stats_file:
+        logger.info("Writing statistics files")
         summary.writeMoleculeStats(output_prefix=args.stats_file, allMolecules=allMolecules)
 
 def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary):

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -18,7 +18,6 @@ def main(args):
     # Build allMolecules.final_dict[barcode][moleculeID] = molecule
     # molecule are instances of Molecule, defined as proximal reads if they are more than min_reads argument.
     logger.info(f'Running analysis with {"{:,}".format(args.window)} bp window size')
-    logger.info('Fetching reads')
     with pysam.AlignmentFile(args.x2_bam, 'rb') as infile:
         allMolecules = build_molecule_dict(pysam_openfile=infile, barcode_tag=args.barcode_tag, window=args.window, min_reads=args.threshold, summary=summary)
         allMolecules.reportAndRemoveAll()
@@ -34,7 +33,7 @@ def main(args):
     # Writes output bam file if wanted
     with pysam.AlignmentFile(args.x2_bam, 'rb') as openin:
         with pysam.AlignmentFile(args.output, 'wb', template=openin) as openout:
-            logging.info("Writing filtered bam file")
+            logger.info("Writing filtered bam file")
             for read in tqdm(openin.fetch(until_eof=True)):
 
                 # If no bc_id, just write it to out
@@ -68,6 +67,7 @@ def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary)
     allMolecules = AllMolecules(min_reads=min_reads)
 
     prev_chrom = pysam_openfile.references[0]
+    logger.info("Dividing barcodes into molecules")
     for read in tqdm(pysam_openfile.fetch(until_eof=True)):
 
         # Fetches barcode and genomic position. Position will be formatted so start < stop.

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -23,9 +23,9 @@ def main(args):
     logger.info('Fetching reads')
     with pysam.AlignmentFile(args.x2_bam, 'rb') as infile:
         prev_chrom = infile.references[0]
+        summary.reads = infile.mapped + infile.unmapped
         for read in tqdm(infile.fetch(until_eof=True)):
 
-            # Progress reporting. Upmost because of continue-statement in loop
 
             # Fetches barcode and genomic position. Position will be formatted so start < stop.
             BC_id, read_start, read_stop, summary = fetch_and_format(read, args.barcode_tag, summary=summary)
@@ -64,7 +64,6 @@ def main(args):
 
     # Commit last chr molecules and log stats
     molecules.reportAndRemoveAll(summary=summary)
-    #summary.reads = progress.position
     summary.non_analyzed_reads = summary.unmapped_reads + summary.non_tagged_reads + summary.overlapping_reads_in_pb
     logger.info('Molecules analyzed')
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -56,19 +56,11 @@ def main(args):
 
                 openout.write(read)
 
-
-
-        # Stats to output files and stdout
+    # Stats to output files and stdout
+    summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
     if args.print_stats:
         summary.writeMoleculeStats(output_prefix=args.print_stats, Max_molecules=args.Max_molecules,
                                  allMolecules=allMolecules)
-        summary.printStats(barcode_tag=args.barcode_tag, threshold=args.threshold, allMolecules=allMolecules)
-
-    try:
-        logger.info(f'Reads with barcodes removed:\t{"{:,}".format(summary.reads_with_removed_barcode)}\t'
-                    f'({"%.2f" % ((summary.reads_with_removed_barcode/summary.tot_reads)*100)}%)')
-    except ZeroDivisionError:
-        logger.warning('No reads passing filters found in file.')
 
 def build_molecule_dict(pysam_openfile, barcode_tag, window, min_reads, summary):
 
@@ -246,6 +238,12 @@ class Summary:
         logger.info(f'Molecules total (min read {threshold}):\t{"{:,}".format(sum(len(all) for all in allMolecules.final_dict.values()))}')
         logger.info(f'Barcodes removed:\t{len(self.barcode_removal_set)}')
         logger.info(f'Molecules removed:\t{self.number_removed_molecules}')
+
+        try:
+            logger.info(f'Reads with barcodes removed:\t{"{:,}".format(self.reads_with_removed_barcode)}\t'
+                        f'({"%.2f" % ((summary.reads_with_removed_barcode/self.tot_reads)*100)}%)')
+        except ZeroDivisionError:
+            logger.warning('No reads passing filters found in file.')
 
     def writeMoleculeStats(self, output_prefix, Max_molecules, allMolecules):
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -1,6 +1,6 @@
 """
 Removes barcode tags present at more than -M loci (corresponding to removing barcode tags from reads origin to droplets
-which had more than -M molecules).
+which had more than -M molecules in one and the same droplet).
 """
 
 import pysam
@@ -8,7 +8,6 @@ import logging
 
 from tqdm import tqdm
 
-import blr.utils as BLR
 
 logger = logging.getLogger(__name__)
 
@@ -331,7 +330,8 @@ class Summary:
 
 
 def add_arguments(parser):
-    parser.add_argument("x2_bam", help=".bam file tagged with @RG tags and duplicates removed. Needs to be indexed.")
+    parser.add_argument("x2_bam", help=".bam file tagged with BC:Z:<int> tags. Needs to be indexed, sorted & have "
+                                       "duplicates removed.")
     parser.add_argument("output", help="Output filtered file.")
     parser.add_argument("-F", "--force_run", action="store_true", help="Run analysis even if not running python 3. "
                                                                        "Not recommended due to different function "

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -20,7 +20,9 @@ def main(args):
     logger.info(f'Running analysis with {"{:,}".format(args.window)} bp window size')
     logger.info('Fetching reads')
     progress = BLR.ProgressReporter('Reads processed', 1000000)
+    prev_chrom = infile.references[0]
     with pysam.AlignmentFile(args.x2_bam, 'rb') as infile:
+
         for read in infile.fetch(until_eof=True):
 
             # Progress reporting. Upmost because of continue-statement in loop

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -247,22 +247,21 @@ class Summary:
     def writeMoleculeStats(self, output_prefix, allMolecules):
 
         # Opening all files
-        molecules_per_bc_out = open((output_prefix + '.molecules_per_bc'), 'w')
-        reads_per_molecule_out = open((output_prefix + '.reads_per_molecule'), 'w')
-        molecule_len_out = open((output_prefix + '.molecule_lengths'), 'w')
-        everything = open((output_prefix + '.everything'), 'w')
+        molecules_per_bc = open((output_prefix + '.molecules_per_bc'), 'w')
+        molecule_stats = open((output_prefix + '.molecule_stats'), 'w')
 
         # Writing molecule-dependant stats
         for barcode in tqdm(allMolecules.final_dict):
-            molecules_per_bc_out.write(str(len(allMolecules.final_dict[barcode])))
+            number_of_molecules = len(allMolecules.final_dict[barcode])
+            molecules_per_bc.write(str(number_of_molecules))
             for molecule in (allMolecules.final_dict[barcode]):
-                everything.write(str(molecule.number_of_reads) + '\t' + str(molecule.length()) + '\t' + str(barcode) + '\t' + str(len(allMolecules.final_dict[barcode])) + '\n')
+                molecule_stats.write(str(molecule.number_of_reads) + '\t' + str(molecule.length()) + '\t' + barcode + '\t' + str(number_of_molecules) + '\n')
 
             # Stats tracker needed to split bam files into separate according barcode per molecule
-            self.bc_to_numberMolecules[barcode] = len(allMolecules.final_dict[barcode])
+            self.bc_to_numberMolecules[barcode] = number_of_molecules
 
         # Close files
-        for output_file in (molecules_per_bc_out, reads_per_molecule_out, molecule_len_out, everything):
+        for output_file in (molecules_per_bc, molecule_stats):
             output_file.close()
 
 def add_arguments(parser):
@@ -281,9 +280,8 @@ def add_arguments(parser):
                                                                               "DEFAULT: 30000")
     parser.add_argument("-bc", "--barcode_tag", metavar='<STRING>', type=str, default='BC',
                         help="Bam file tag where barcode is stored. DEFAULT: BC")
-    parser.add_argument("-ps", "--print_stats", metavar='<PREFIX>', type=str,
-                        help="Write barcode statistics files (reads per molecule, molecule per barcode, molecule "
-                             "lengths & coupling effiency). DEFAULT: None")
+    parser.add_argument("-s", "--stats_file", metavar='<PREFIX>', type=str,
+                        help="Write barcode/molecule statistics files.")
     parser.add_argument("-M", "--Max_molecules", metavar='<INTEGER>', type=int, default=500,
                         help="When using -f (--filter) this will remove barcode tags for those clusters which have more "
                              "than -M molecules. DEFAULT: 500")

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -36,18 +36,13 @@ def main(args):
             if BC_id in allMolecules.cache_dict:
                 molecule = allMolecules.cache_dict[BC_id]
 
-                # Read is within args.window => add read to molecule.
-                if (molecule.stop+args.window) >= read_start and molecule.stop < read_start:
-                    molecule.addRead(stop=read_stop, read_header=read.query_name)
-                    allMolecules.cache_dict[BC_id] = molecule
-
-                # Overlapping reads => If not overlapping to it's mate, discard read.
-                elif molecule.stop >= read_start:
-                    if read.query_name in molecule.read_headers:
+                # Read is within args.window => add read to molecule (don't include overlapping reads).
+                if (molecule.stop+args.window) >= read_start:
+                    if molecule.stop >= read_start:
+                        summary.overlapping_reads_in_pb += 1
+                    else:
                         molecule.addRead(stop=read_stop, read_header=read.query_name)
                         allMolecules.cache_dict[BC_id] = molecule
-                    else:
-                        summary.overlapping_reads_in_pb += 1
 
                 # Read is not within window => report old and initiate new molecule for that barcode.
                 else:


### PR DESCRIPTION
Resolving #43 and rewriting filtercluster to be more readable while keeping the same function.

Briefly what was done:
- Move everything regarding counting of reads/molecules in barcodes to their own objects
- Move most main function code to smaller functions 
- Change variable names to more intuitive names
- Add & update documentation
- Write (more) according to pep8 (Glad to accept feedback on this point in particular)
- Made standard functionality to be writing filtered bam files with optional molecule/barcode stats generation instead of the other way around
- Removed outdated functions & options
- Changed statistics output format to be one file for molecule stats and one for barcodes

**Notable changes**
- Remove utils dependency
- tqdm for reporting over iterations (external module)
- Changed args (option names & positional args)

There is **one change** to output, the filtered reads have a slight format change. Prev format: 

```<header>_<bc_seq>_<bc_clust_id>``` => ```<header>_<bc_seq>```

New format:

```<header>_<bc_seq>_<bc_clust_id>``` => ```<header>_FILTERED-<bc_seq>_<bc_clust_id>```

Where ```bc_clust_id``` corresponds to the error-corrected barcode.