### PR TITLE
Snakemake piped rules merged into single rule 

### DIFF
--- a/rules/trim.smk
+++ b/rules/trim.smk
@@ -19,7 +19,7 @@ rule trimming:
         b = "{dir}/trimmed-b.log"
     threads: 20
     shell:
-        "cutadapt"
+        "cutadapt" #Initial trim
         " -g ^CAGTTGATCATCAGCAGGTAATCTGG"
         " -e 0.2"
         " --discard-untrimmed"
@@ -30,10 +30,10 @@ rule trimming:
         " {input.r1_fastq}"
         " {input.r2_fastq}"
         " 2> {log.a} |"
-        " blr extractbarcode"
+        " blr extractbarcode" #Extract barcodes
         " -"
         " -o1 - |" 
-        " cutadapt"
+        " cutadapt" # Final trim
         " -a ^CATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAG...CTGTCTCTTATACACATCT"
         " -A CTGTCTCTTATACACATCT"
         " -e 0.2"

--- a/rules/trim.smk
+++ b/rules/trim.smk
@@ -1,47 +1,10 @@
-from snakemake.utils import available_cpu_count
-from math import ceil
+"""
+Rules connected to trimming of fastq files.
+"""
 
-# Piped trimming of reads, executed if -j/--jobs/--cores is given with number larger
-# then or equal to 3 as there are 3 processes in the pipe. Intermediate fastqs are interleaved.
-# If less than 3 are given a WorkflowError will be raised, therefore I have set this condition and also
-# limited the number of threads used to a 1/3 of available.
-# See the following issue from more information:
-# https://bitbucket.org/snakemake/snakemake/issues/1039/split-number-of-threads-for-a-rule
-
-rule trim_r1_handle_pipe:
-    #Trim away E handle on R1 5'. Also removes reads shorter than 85 bp.
-    output:
-        interleaved_fastq=pipe("{dir}/trimmed-a.fastq")
-    input:
-        r1_fastq="{dir}/reads.1.fastq.gz",
-        r2_fastq="{dir}/reads.2.fastq.gz"
-    log: "{dir}/trimmed-a.log"
-    threads: ceil((available_cpu_count()-1)/2)
-    shell:
-        "cutadapt"
-        " -g ^CAGTTGATCATCAGCAGGTAATCTGG"
-        " -e 0.2"
-        " --discard-untrimmed"
-        " -j {threads}"
-        " -m 65"
-        " -o {output.interleaved_fastq}"
-        " --interleaved "
-        " {input.r1_fastq}"
-        " {input.r2_fastq}"
-        " > {log}"
-
-rule extract_barcodes_pipe:
-    output:
-        interleaved_fastq=pipe("{dir}/unbarcoded.fastq")
-    input:
-        interleaved_fastq="{dir}/trimmed-a.fastq"
-    shell:
-        # BDHVBDVHBDVHBDVH
-        "blr extractbarcode"
-        " {input.interleaved_fastq}"
-        " -o1 {output.interleaved_fastq}"
-
-rule final_trim_pipe:
+rule trimming:
+    # Trim away E handle on R1 5'. Also removes reads shorter than 85 bp.
+    # Extract barcode sequence and place in header.
     # Cut H1691' + TES sequence from 5' of R1. H1691'=CATGACCTCTTGGAACTGTC, TES=AGATGTGTATAAGAGACAG.
     # Cut 3' TES' sequence from R1 and R2. TES'=CTGTCTCTTATACACATCT
     # Discard untrimmed.
@@ -49,13 +12,30 @@ rule final_trim_pipe:
         r1_fastq="{dir}/trimmed-c.1.fastq.gz",
         r2_fastq="{dir}/trimmed-c.2.fastq.gz"
     input:
-        interleaved_fastq="{dir}/unbarcoded.fastq"
-    log: "{dir}/trimmed-b.log"
-    threads: int((available_cpu_count()-1)/2)
+        r1_fastq="{dir}/reads.1.fastq.gz",
+        r2_fastq="{dir}/reads.2.fastq.gz"
+    log:
+        a = "{dir}/trimmed-a.log",
+        b = "{dir}/trimmed-b.log"
+    threads: 20
     shell:
         "cutadapt"
-        " -a ^CATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAG...CTGTCTCTTATACACATCT "
-        " -A CTGTCTCTTATACACATCT "
+        " -g ^CAGTTGATCATCAGCAGGTAATCTGG"
+        " -e 0.2"
+        " --discard-untrimmed"
+        " -j {threads}"
+        " -m 65"
+        " -o -"
+        " --interleaved"
+        " {input.r1_fastq}"
+        " {input.r2_fastq}"
+        " 2> {log.a} |"
+        " blr extractbarcode"
+        " -"
+        " -o1 - |" 
+        " cutadapt"
+        " -a ^CATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAG...CTGTCTCTTATACACATCT"
+        " -A CTGTCTCTTATACACATCT"
         " -e 0.2"
         " --discard-untrimmed"
         " --pair-filter 'first'"
@@ -63,6 +43,6 @@ rule final_trim_pipe:
         " -m 25"
         " -o {output.r1_fastq}"
         " -p {output.r2_fastq}"
-        " {input.interleaved_fastq}"
+        " -"
         " --interleaved"
-        " > {log}"
+        " > {log.b}"

--- a/rules/trim.smk
+++ b/rules/trim.smk
@@ -2,7 +2,7 @@
 Rules connected to trimming of fastq files.
 """
 
-rule trimming:
+rule trim:
     # Trim away E handle on R1 5'. Also removes reads shorter than 85 bp.
     # Extract barcode sequence and place in header.
     # Cut H1691' + TES sequence from 5' of R1. H1691'=CATGACCTCTTGGAACTGTC, TES=AGATGTGTATAAGAGACAG.


### PR DESCRIPTION
Fix to issue #67 

Joined three piped rules into one and used standard pipes. This is a bit harder to read as the shell command is so massive. However it does not have the same problems with thread distribution as using the snakemake pipe() functionality. 