### PR TITLE
Test script updates

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,14 +3,13 @@ set -xeuo pipefail
 
 ( cd testdata && bowtie2-build chr1mini.fasta chr1mini > /dev/null )
 
-# test single core execution
 rm -rf outdir
 mkdir -p outdir
 ln -s $PWD/testdata/reads.1.fastq.gz outdir/reads.1.fastq.gz
 ln -s $PWD/testdata/reads.2.fastq.gz outdir/reads.2.fastq.gz
 
 snakemake --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
-    outdir/reads.2.final.fastq.gz -j 3
+    outdir/reads.2.final.fastq.gz
 
 m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
-test $m == faccb608e13c184c7ff0625c65dca78f
+test $m == 7f0d3e8bd8d5f147c1f4c4234b4e1efe

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,4 +1,4 @@
-index_nucleotides: 3
+index_nucleotides: 1
 heap_space: 3
 cluster_tag: BC    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini


### PR DESCRIPTION
Reduced number of index nucleotides from 3 to 1 to make test output less massive. Changed back to single core execution from three cores as this is no longer required. Update md5sum.