### PR TITLE
Keep read duplicates

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -193,5 +193,4 @@ rule bam_to_fastq:
         "{params.picard_command} -Xms{params.heap_space}g SamToFastq"
         " I={input.bam}"
         " FASTQ={output.r1_fastq}"
-        " VALIDATION_STRINGENCY=SILENT"
         " SECOND_END_FASTQ={output.r2_fastq} 2>> {log}"


### PR DESCRIPTION
Solving #18. Only mark duplicates instead of removing and then marking to find barcode duplicates. This included:

- Removal of read duplicate removal set
- clusterrmdup now requires at least two barcodes at a duplicate position to save it in cache for later analysis (not needed before since it could be assumed)
- filterrclusters 
- Changed md5sum to match
- Removed silence option from SamToFastq step

Since md5sum was not comparable before and after, the last bam files coverage graph (samtools depth output) md5sum was compared instead.

All changes except the last were mistakenly included into PR #68 and instead I'll write the names here. Commit names not included in this PR:

Aug 26, 2019
- Change md5sum (duplicates left in file & other minor changes)

Aug 20, 2019
- Adjust name to fit snakefile (keep read dup+namechange x2 => bcmerge)
- Add row to skip reads marked as duplicates in file
- Require at least two different barcodes at a given rp position
- Remove picard read rmdup step and adjust names (also changed from x2 …