### PR TITLE
Write settings

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -130,7 +130,7 @@ rule duplicates_marking:
         bam = "{dir}/mapped.sorted.tag.bam"
     log:
         metrics = "{dir}/picard_mkdup_metrics.log",
-        stderr = "{dir}/4_rmdup.log"
+        stderr = "{dir}/picard_mkdup.log"
     params:
         picard_command = config["picard_command"],
         heap_space=config["heap_space"]
@@ -149,7 +149,7 @@ rule clusterrmdup_and_index:
         merges = "{dir}/barcode-merges.csv"
     input:
         bam = "{dir}/mapped.sorted.tag.mkdup.bam"
-    log: "{dir}/4_rmdup.log"
+    log: "{dir}/clusterrmdup.log"
     shell:
         "blr clusterrmdup"
         " {input.bam}"
@@ -167,7 +167,7 @@ rule filterclusters:
         stat2 = "{dir}/cluster_stats/bcmerge.stats.molecule_stats"
     input:
         bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.bam"
-    log: "{dir}/4_rmdup.log"
+    log: "{dir}/filterclusters.log"
     params:
         stats = "{dir}/cluster_stats/bcmerge.stats"
     shell:

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -34,6 +34,8 @@ def main() -> int:
     if not hasattr(args, "module"):
         parser.error("Please provide the name of a subcommand to run")
     else:
+        for object_variable, value in vars(args).items():
+            logger.info(f"{object_variable}: {value}")
         module = args.module
         del args.module
         module.main(args)

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -35,7 +35,7 @@ def main() -> int:
         parser.error("Please provide the name of a subcommand to run")
     else:
         for object_variable, value in vars(args).items():
-            logger.info(f"{object_variable}: {value}")
+            sys.stderr.write(f"main - SETTINGS: {object_variable}: {value}\n")
         module = args.module
         del args.module
         module.main(args)

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logging.basicConfig(level=logging.INFO, format="%(module)s - %(levelname)s: %(message)s")
     parser = ArgumentParser(description=__doc__, prog="blr")
     parser.add_argument("--version", action="version", version="%(prog)s 0.1")
     subparsers = parser.add_subparsers()

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -34,10 +34,14 @@ def main() -> int:
     if not hasattr(args, "module"):
         parser.error("Please provide the name of a subcommand to run")
     else:
-        for object_variable, value in vars(args).items():
-            sys.stderr.write(f"main - SETTINGS: {object_variable}: {value}\n")
         module = args.module
         del args.module
+
+        # Print settings for module
+        sys.stderr.write(f"SETTINGS FOR: {module.__name__.split('.')[-1]}")
+        for object_variable, value in vars(args).items():
+            sys.stderr.write(f" {object_variable}: {value}\n")
+
         module.main(args)
 
     return 0


### PR DESCRIPTION
In order to always know what settings have been used I added some rows to main to it always starts with writing all things defined from args, I also added the levelname to logger so one can see which submodule is producing the messages.

With an increasing amount of options this might become a quite massive string, but we don't have to many options yet and in that case I'd throw in a check so it only prints the non-default arguments used (but havn't quite figured out how to do that yet).

I also fixed the log going to 4_rmdup.log which were all overwriting each other.

Example of output:
```
main - SETTINGS: input_tagged_bam: mapped.sorted.tag.mkdup.bam
main - SETTINGS: output_bam: mapped.sorted.tag.mkdup.bcmerge.bam
main - SETTINGS: merge_log: barcode-merges.csv
main - SETTINGS: barcode_tag: BC
main - SETTINGS: window: 100000
main - SETTINGS: module: <module 'blr.cli.clusterrmdup' from '/Users/tobiasfrick/PycharmProjects/masters/BLR/src/blr/cli/clusterrmdup.py'>
clusterrmdup - INFO: Starting Analysis
Processing reads: 19976it [00:00, 38105.78it/s]
Writing output: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19976/19976 [00:00<00:00, 118471.67it/s]
clusterrmdup - INFO: Total Reads in file: 19976
clusterrmdup - INFO:   Unmapped reads: 1270
clusterrmdup - INFO:   Reads with unmapped mate: 1102
clusterrmdup - INFO:   Reads without BC tag: 0
clusterrmdup - INFO:   Reads analyzed: 17604
clusterrmdup - INFO: Reads at dup pos: 3468
clusterrmdup - INFO: Reads with new tag: 3696
clusterrmdup - INFO: BC tags removed: 268
clusterrmdup - INFO: Finished
```

