### PR TITLE
Phasing pipeline 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,6 @@ install:
   - conda env create -n testenv -f environment.yml
   - conda activate testenv
   - pip install .
+  - bash install-hapcut2.sh
 
 script: tests/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
   - conda config --add channels bioconda --add channels conda-forge
   - conda info -a
   - wget https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.1.tar.gz
-  - tar xf blr-testdata-0.1.tar.gz
-  - ln -s blr-testdata-0.1 testdata
+  - tar xf blr-testdata-0.2.tar.gz
+  - ln -s blr-testdata-0.2 testdata
 
 install:
   - conda env create -n testenv -f environment.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - conda update -q conda
   - conda config --add channels bioconda --add channels conda-forge
   - conda info -a
-  - wget https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.1.tar.gz
+  - wget https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.2.tar.gz
   - tar xf blr-testdata-0.2.tar.gz
   - ln -s blr-testdata-0.2 testdata
 

--- a/Snakefile
+++ b/Snakefile
@@ -233,7 +233,7 @@ rule HAPCUT2_extractHAIRS:
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_extracthairs.log"
     shell:
-         "{HAPCUT2}/build/extractHAIRS"
+         "config[hapcut2]/build/extractHAIRS"
          " --10X 1"
          " --bam {input.bam}"
          " --VCF {input.vcf}"
@@ -248,7 +248,7 @@ rule HAPCUT2_LinkFragments:
         unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
     log: "{dir}/hapcut2_linkfragments.log"
     shell:
-         "python {HAPCUT2}/utilities/LinkFragments.py"
+         "python config[hapcut2]/utilities/LinkFragments.py"
          " --bam {input.bam}"
          " -v {input.vcf}"
          " --fragments {input.unlinked}"
@@ -263,7 +263,7 @@ rule HAPCUT2_phasing:
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
     shell:
-         "{HAPCUT2}/build/HAPCUT2"
+         "{config[hapcut2]}/build/HAPCUT2"
          " --nf 1"
          " --fragments {input.linked}"
          " --vcf {input.vcf}"

--- a/Snakefile
+++ b/Snakefile
@@ -181,16 +181,21 @@ rule filterclusters:
     # Filter clusters based on parameters
     output:
         bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
+        bai = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam.bai"
     input:
         bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.bam"
     log: "{dir}/filterclusters.log"
     shell:
         "blr filterclusters"
         " {input.bam}"
-        " {output.bam}"
+        " -"
         " -mn {config[num_mol_tag]}"
         " -M 260"
-        " -t {config[cluster_tag]} {config[molecule_tag]} {config[num_mol_tag]} {config[sequence_tag]} 2> {log}"
+        " -t {config[cluster_tag]} {config[molecule_tag]} {config[num_mol_tag]} {config[sequence_tag]}"
+        " 2>> {log} |"
+        " tee {output.bam} |"
+        " samtools index  - {output.bai}"
+
 
 rule bam_to_fastq:
     # Convert final bam file to fastq files for read 1 and 2

--- a/Snakefile
+++ b/Snakefile
@@ -217,5 +217,48 @@ rule call_variants_freebayes:
          " -f {params.reference}"
          " {input.bam} 1> {output.vcf} 2> {log}"
 
+rule HAPCUT2_extractHAIRS:
+    output:
+        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+    input:
+        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.vcf"
+    log: "{dir}/hapcut2_extracthairs.log"
+    shell:
+         "{HAPCUT2}/build/extractHAIRS"
+         " --10X 1"
+         " --bam {input.bam}"
+         " --VCF {input.vcf}"
+         " --out {output.unlinked} 2> {log}"
 
+rule HAPCUT2_LinkFragments:
+    output:
+        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked"
+    input:
+        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.vcf",
+        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+    log: "{dir}/hapcut2_linkfragments.log"
+    shell:
+         "python {HAPCUT2}/utilities/LinkFragments.py"
+         " --bam {input.bam}"
+         " -v {input.vcf}"
+         " --fragments {input.unlinked}"
+         " --out {output.linked} &> {log}"
+
+rule HAPCUT2_phasing:
+    output:
+        phase = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase",
+        phased_vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf"
+    input:
+        vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.vcf",
+        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked"
+    log: "{dir}/hapcut2_phasing.log"
+    shell:
+         "{HAPCUT2}/build/HAPCUT2"
+         " --nf 1"
+         " --fragments {input.linked}"
+         " --vcf {input.vcf}"
+         " --out {output.phase}"
+         " --outvcf 1 2> {log}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -203,3 +203,19 @@ rule bam_to_fastq:
         " I={input.bam}"
         " FASTQ={output.r1_fastq}"
         " SECOND_END_FASTQ={output.r2_fastq} 2>> {log}"
+
+rule call_variants_freebayes:
+    output:
+         vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.vcf"
+    input:
+         bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam"
+    log: "{dir}/call_variants_freebayes.log"
+    params:
+        reference = config["bowtie2_reference"] + ".fasta" # I am unsure if this is a good solution, but it works.
+    shell:
+         "freebayes"
+         " -f {params.reference}"
+         " {input.bam} 1> {output.vcf} 2> {log}"
+
+
+

--- a/Snakefile
+++ b/Snakefile
@@ -5,6 +5,8 @@ import os
 configfile: "config.yaml"
 validate(config, "config.schema.yaml")
 
+HAPCUT2="/Users/pontus.hojer/Applications/HapCUT2"
+
 # Create list of files to be created in cdhitprep
 indexes = sorted(["".join(tup) for tup in itertools.product("ATCG", repeat=config["index_nucleotides"])]) \
                 if config["index_nucleotides"] > 0 else ["all"]

--- a/Snakefile
+++ b/Snakefile
@@ -212,7 +212,7 @@ if config['call_variants']:
         output:
              vcf = "{dir}/reference.vcf"
         input:
-             bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam"
+             bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.bam"
         log: "{dir}/call_variants_freebayes.log"
         params:
             reference = config["bowtie2_reference"] + ".fasta" # I am unsure if this is a good solution, but it works.

--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,4 @@
-from snakemake.utils import validate, WorkflowError
+from snakemake.utils import validate
 import itertools
 import os
 
@@ -212,7 +212,14 @@ rule bam_to_fastq:
         " FASTQ={output.r1_fastq}"
         " SECOND_END_FASTQ={output.r2_fastq} 2>> {log}"
 
-if config['call_variants']:
+if config['reference_variants']:
+    rule link:
+        output: "{dir}/reference.vcf"
+        params: config['reference_variants']
+        run:
+            cmd = "ln -s " + os.path.abspath(config['reference_variants']) + " " + str(output)
+            shell(cmd)
+else:
     rule call_variants_freebayes:
         output:
              vcf = "{dir}/reference.vcf"
@@ -225,13 +232,3 @@ if config['call_variants']:
              "freebayes"
              " -f {params.reference}"
              " {input.bam} 1> {output.vcf} 2> {log}"
-elif os.path.exists(config['reference_variants']):
-    rule link:
-        output: "{dir}/reference.vcf"
-        params: config['reference_variants']
-        run:
-            cmd = "ln -s " + os.path.abspath(config['reference_variants']) + " " + str(output)
-            shell(cmd)
-else:
-    raise WorkflowError("Either call_variants must be set to true or path to reference_variants be supplied.")
-

--- a/Snakefile
+++ b/Snakefile
@@ -224,7 +224,9 @@ elif os.path.exists(config['reference_variants']):
     rule link:
         output: "{dir}/reference.vcf"
         params: config['reference_variants']
-        shell: "ln -hfs {params} {output}"
+        run:
+            cmd = "ln -s " + os.path.abspath(config['reference_variants']) + " " + str(output)
+            shell(cmd)
 else:
     raise WorkflowError("Either call_variants must be set to true or path to reference_variants be supplied.")
 

--- a/Snakefile
+++ b/Snakefile
@@ -5,8 +5,6 @@ import os
 configfile: "config.yaml"
 validate(config, "config.schema.yaml")
 
-HAPCUT2="/Users/pontus.hojer/Applications/HapCUT2"
-
 # Create list of files to be created in cdhitprep
 indexes = sorted(["".join(tup) for tup in itertools.product("ATCG", repeat=config["index_nucleotides"])]) \
                 if config["index_nucleotides"] > 0 else ["all"]

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -33,6 +33,10 @@ properties:
     type: string
     description: Picard command to be used.
     default: picard
+  hapcut2:
+    type: string
+    description: Hapcut2 command to be used.
+    default: .
   call_variants:
     type: boolean
     description: Call variants for dataset.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -37,14 +37,10 @@ properties:
     type: string
     description: Hapcut2 command to be used.
     default: .
-  call_variants:
-    type: boolean
-    description: Call variants for dataset.
-    default: true
   reference_variants:
     type: string
-    description: Path to reference variants
-    default: .
+    description: Path to reference variants, if not provided then variant will be called by freebayes
+    default:
   phasing_ground_truth:
     type: string
     description: Path to phased variants used to compute phasing stats.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -45,3 +45,7 @@ properties:
     type: string
     description: Path to reference variants
     default: .
+  phasing_ground_truth:
+    type: string
+    description: Path to phased variants used to compute phasing stats.
+    default: .

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -12,7 +12,7 @@ properties:
   cluster_tag:
     type: string
     description: SAM tag to use for store barcode cluster id in bam file. 'BX' is 10x genomic default
-    default: BC
+    default: BX
   molecule_tag:
     type: string
     description: SAM flag used to store molecule ID, same as 10x default.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -33,10 +33,6 @@ properties:
     type: string
     description: Picard command to be used.
     default: picard
-  hapcut2:
-    type: string
-    description: Hapcut2 command to be used.
-    default: .
   call_variants:
     type: boolean
     description: Call variants for dataset.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -33,3 +33,11 @@ properties:
     type: string
     description: Picard command to be used.
     default: picard
+  call_variants:
+    type: boolean
+    description: Call variants for dataset.
+    default: true
+  reference_variants:
+    type: string
+    description: Path to reference variants
+    default: .

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,11 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 bowtie2_reference: .   #Fill in /path/to/bowtie2_reference
 picard_command: picard #Picard run command.
+
+####################
+# Phasing settings #
+####################
 hapcut2: HapCUT2 #Path to Hapcut2 command.
 call_variants: true #Call variants for dataset, this means that reference variants will not be used.
-reference_variants: . #Path to reference variants
+reference_variants: #Path to reference variants used for phasing
+phasing_ground_truth: #Path to phased variants used for calculating stats

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,5 @@ picard_command: picard #Picard run command.
 # Phasing settings #
 ####################
 hapcut2: HapCUT2 #Path to Hapcut2 command.
-call_variants: true #Call variants for dataset, this means that reference variants will not be used.
-reference_variants: #Path to reference variants used for phasing
+reference_variants: #Path to reference variants used for phasing, if not provided then variant will be called by freebayes
 phasing_ground_truth: #Path to phased variants used for calculating stats

--- a/config.yaml
+++ b/config.yaml
@@ -6,5 +6,6 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 bowtie2_reference: .   #Fill in /path/to/bowtie2_reference
 picard_command: picard #Picard run command.
+hapcut2: . #Path to Hapcut2 command.
 call_variants: true #Call variants for dataset, this means that reference variants will not be used.
 reference_variants: . #Path to reference variants

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 index_nucleotides: 3
 heap_space: 90
-cluster_tag: BC    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
+cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default

--- a/config.yaml
+++ b/config.yaml
@@ -5,4 +5,6 @@ molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 bowtie2_reference: .   #Fill in /path/to/bowtie2_reference
-picard_command: picard
+picard_command: picard #Picard run command.
+call_variants: true #Call variants for dataset, this means that reference variants will not be used.
+reference_variants: . #Path to reference variants

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,6 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 bowtie2_reference: .   #Fill in /path/to/bowtie2_reference
 picard_command: picard #Picard run command.
-hapcut2: . #Path to Hapcut2 command.
+hapcut2: HapCUT2 #Path to Hapcut2 command.
 call_variants: true #Call variants for dataset, this means that reference variants will not be used.
 reference_variants: . #Path to reference variants

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - datrie=0.7.1
   - dnaio=0.3
   - docutils=0.14
+  - freebayes=1.3.1
   - gitdb2=2.0.5
   - gitpython=2.1.11
   - htslib=1.9

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -4,7 +4,7 @@ set pipefail -eox
 
 # Based on https://github.com/vibansal/HapCUT2/releases.
 
-git clone https://github.com/vibansal/HapCUT2.git
+git clone --recursive https://github.com/vibansal/HapCUT2.git
 
 cd HapCUT2
 
@@ -12,3 +12,9 @@ cd HapCUT2
 git checkout 3cb79c1
 
 make
+
+# Test install
+
+./build/extractHAIRS
+
+./build/HAPCUT2

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -10,12 +10,6 @@ cd HapCUT2
 
 make
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    sudo make install-hairs
-
-    sudo make install-hapcut2
-fi
-
 # Test install
 
 ./build/extractHAIRS

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -2,8 +2,13 @@
 
 set pipefail -eox
 
+# Based on https://github.com/vibansal/HapCUT2/releases.
+
 git clone https://github.com/vibansal/HapCUT2.git
 
 cd HapCUT2
+
+# For versions 1.1
+git checkout 3cb79c1
 
 make

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -10,6 +10,12 @@ cd HapCUT2
 
 make
 
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    sudo make install-hairs
+
+    sudo make install-hapcut2
+fi
+
 # Test install
 
 ./build/extractHAIRS

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -4,12 +4,9 @@ set pipefail -eox
 
 # Based on https://github.com/vibansal/HapCUT2/releases.
 
-git clone --recursive https://github.com/vibansal/HapCUT2.git
+git clone https://github.com/vibansal/HapCUT2.git
 
 cd HapCUT2
-
-# For versions 1.1
-git checkout 3cb79c1
 
 make
 

--- a/install-hapcut2.sh
+++ b/install-hapcut2.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set pipefail -eox
+
+git clone https://github.com/vibansal/HapCUT2.git
+
+cd HapCUT2
+
+make

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -37,14 +37,12 @@ rule HAPCUT2_phasing:
         linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
-    params:
-        phase = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase"
     shell:
          "{HAPCUT2}/build/HAPCUT2"
          " --nf 1"
          " --fragments {input.linked}"
          " --vcf {input.vcf}"
-         " --out {params.phase}"
+         " --out {output.phase}"
          " --outvcf 1 2> {log}"
 
 rule HapCUT2_stats:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -2,9 +2,9 @@ HAPCUT2=config["hapcut2"]
 
 rule HAPCUT2_extractHAIRS:
     output:
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked"
     input:
-        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.bam",
+        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_extracthairs.log"
     shell:
@@ -16,11 +16,11 @@ rule HAPCUT2_extractHAIRS:
 
 rule HAPCUT2_LinkFragments:
     output:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked"
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked"
     input:
-        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.bam",
+        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
         vcf = "{dir}/reference.vcf",
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked"
     log: "{dir}/hapcut2_linkfragments.log"
     shell:
          "python {HAPCUT2}/utilities/LinkFragments.py"
@@ -31,10 +31,10 @@ rule HAPCUT2_LinkFragments:
 
 rule HAPCUT2_phasing:
     output:
-        phase =      "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase",
-        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.VCF"
+        phase =      "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase",
+        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF"
     input:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked",
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
     shell:
@@ -49,7 +49,7 @@ rule HapCUT2_stats:
     output:
         stats = "{dir}/phasing_stats.txt"
     input:
-         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.VCF",
+         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF",
     params:
           vcf2 = config["phasing_ground_truth"]
     shell:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -31,27 +31,25 @@ rule HAPCUT2_LinkFragments:
 
 rule HAPCUT2_phasing:
     output:
-        phase = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase",
-        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf"
+        phase =      "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase",
+        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.VCF"
     input:
         linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
-    params:
-        phase = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase"
     shell:
          "{HAPCUT2}/build/HAPCUT2"
          " --nf 1"
          " --fragments {input.linked}"
          " --vcf {input.vcf}"
-         " --out {params.phase}"
+         " --out {output.phase}"
          " --outvcf 1 2> {log}"
 
 rule HapCUT2_stats:
     output:
         stats = "{dir}/phasing_stats.txt"
     input:
-         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf",
+         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.VCF",
     params:
           vcf2 = config["phasing_ground_truth"]
     shell:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -44,3 +44,16 @@ rule HAPCUT2_phasing:
          " --vcf {input.vcf}"
          " --out {output.phase}"
          " --outvcf 1 2> {log}"
+
+rule HapCUT2_stats:
+    output:
+        stats = "{dir}/phasing_stats.txt"
+    input:
+         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf",
+    params:
+          vcf2 = config["phasing_ground_truth"]
+    shell:
+         "python {HAPCUT2}/utilities/calculate_haplotype_statistics.py"
+         " -v1 {input.vcf1}"
+         " -v2 {params.vcf2}"
+         " > {output.stats}"

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -2,9 +2,9 @@ HAPCUT2=config["hapcut2"]
 
 rule HAPCUT2_extractHAIRS:
     output:
-        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.unlinked"
     input:
-        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.bam",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_extracthairs.log"
     shell:
@@ -16,11 +16,11 @@ rule HAPCUT2_extractHAIRS:
 
 rule HAPCUT2_LinkFragments:
     output:
-        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked"
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked"
     input:
-        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.bam",
         vcf = "{dir}/reference.vcf",
-        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.unlinked"
     log: "{dir}/hapcut2_linkfragments.log"
     shell:
          "python {HAPCUT2}/utilities/LinkFragments.py"
@@ -31,10 +31,10 @@ rule HAPCUT2_LinkFragments:
 
 rule HAPCUT2_phasing:
     output:
-        phase = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase",
-        phased_vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf"
+        phase = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase",
+        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf"
     input:
-        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked",
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
     shell:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -1,0 +1,46 @@
+HAPCUT2=config["hapcut2"]
+
+rule HAPCUT2_extractHAIRS:
+    output:
+        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+    input:
+        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        vcf = "{dir}/reference.vcf"
+    log: "{dir}/hapcut2_extracthairs.log"
+    shell:
+         "{HAPCUT2}/build/extractHAIRS"
+         " --10X 1"
+         " --bam {input.bam}"
+         " --VCF {input.vcf}"
+         " --out {output.unlinked} 2> {log}"
+
+rule HAPCUT2_LinkFragments:
+    output:
+        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked"
+    input:
+        bam = "{dir}/mapped.sorted.tag.rmdup.x2.filt.bam",
+        vcf = "{dir}/reference.vcf",
+        unlinked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.unlinked"
+    log: "{dir}/hapcut2_linkfragments.log"
+    shell:
+         "python {HAPCUT2}/utilities/LinkFragments.py"
+         " --bam {input.bam}"
+         " -v {input.vcf}"
+         " --fragments {input.unlinked}"
+         " --out {output.linked} &> {log}"
+
+rule HAPCUT2_phasing:
+    output:
+        phase = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase",
+        phased_vcf = "{dir}/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf"
+    input:
+        linked = "{dir}/mapped.sorted.tag.rmdup.x2.filt.linked",
+        vcf = "{dir}/reference.vcf"
+    log: "{dir}/hapcut2_phasing.log"
+    shell:
+         "{HAPCUT2}/build/HAPCUT2"
+         " --nf 1"
+         " --fragments {input.linked}"
+         " --vcf {input.vcf}"
+         " --out {output.phase}"
+         " --outvcf 1 2> {log}"

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -1,8 +1,8 @@
 HAPCUT2=config["hapcut2"]
 
-rule HAPCUT2_extractHAIRS:
+rule hapcut2_extracthairs:
     output:
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
     input:
         bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
         vcf = "{dir}/reference.vcf"
@@ -14,13 +14,13 @@ rule HAPCUT2_extractHAIRS:
          " --VCF {input.vcf}"
          " --out {output.unlinked} 2> {log}"
 
-rule HAPCUT2_LinkFragments:
+rule hapcut2_linkfragments:
     output:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked"
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt"
     input:
         bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
         vcf = "{dir}/reference.vcf",
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked"
+        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
     log: "{dir}/hapcut2_linkfragments.log"
     shell:
          "python {HAPCUT2}/utilities/LinkFragments.py"
@@ -29,12 +29,12 @@ rule HAPCUT2_LinkFragments:
          " --fragments {input.unlinked}"
          " --out {output.linked} &> {log}"
 
-rule HAPCUT2_phasing:
+rule hapcut2_phasing:
     output:
         phase =      "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase",
         phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF"
     input:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked",
+        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
     shell:
@@ -45,7 +45,7 @@ rule HAPCUT2_phasing:
          " --out {output.phase}"
          " --outvcf 1 2> {log}"
 
-rule HapCUT2_stats:
+rule hapcut2_stats:
     output:
         stats = "{dir}/phasing_stats.txt"
     input:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -37,12 +37,14 @@ rule HAPCUT2_phasing:
         linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.linked",
         vcf = "{dir}/reference.vcf"
     log: "{dir}/hapcut2_phasing.log"
+    params:
+        phase = "{dir}/mapped.sorted.tag.mkdup.bcmerge.filt.phase"
     shell:
          "{HAPCUT2}/build/HAPCUT2"
          " --nf 1"
          " --fragments {input.linked}"
          " --vcf {input.vcf}"
-         " --out {output.phase}"
+         " --out {params.phase}"
          " --outvcf 1 2> {log}"
 
 rule HapCUT2_stats:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -8,14 +8,15 @@ mkdir -p outdir
 ln -s $PWD/testdata/reads.1.fastq.gz outdir/reads.1.fastq.gz
 ln -s $PWD/testdata/reads.2.fastq.gz outdir/reads.2.fastq.gz
 
-snakemake --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
+snakemake -p --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
     outdir/reads.2.final.fastq.gz
 
 m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
 test $m == be2dbe2f5a2ab660a949e1944e077a79
 
 # Test phasing
-snakemake --configfile tests/test_config.yaml outdir/phasing_stats.txt
+snakemake -p --configfile tests/test_config.yaml outdir/phasing_stats.txt
 
-m2=$(md5sum outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase | cut -f1 -d" ")
-test $m2 == 5959009bb88bee382932a4080954cdb3
+# Cut away columns 2 and 3 as these change order between linux and osx
+m2=$(cut -f1,4- outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase | md5sum | cut -f1 -d" ")
+test $m2 == 70c907df8a996d2b3ba3f06fb942b244

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,5 +18,5 @@ test $m == be2dbe2f5a2ab660a949e1944e077a79
 snakemake --configfile tests/test_config.yaml outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase \
     outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf
 
-m2=$(md5sum outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf | cut -f1 -d" ")
-test $m2 == deaa1f8820fdd0d75fd358fffa0bb4ec
+m2=$(md5sum outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase | cut -f1 -d" ")
+test $m2 == 5959009bb88bee382932a4080954cdb3

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,12 +11,12 @@ ln -s $PWD/testdata/reads.2.fastq.gz outdir/reads.2.fastq.gz
 snakemake -p --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
     outdir/reads.2.final.fastq.gz
 
-m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
-test $m == 53df30b14f6cc184758a4711f08daf43
+m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
+test $m == 134db15680443fc32d25ba577a0c5700
 
 # Test phasing
 snakemake -p --configfile tests/test_config.yaml outdir/phasing_stats.txt
 
 # Cut away columns 2 and 3 as these change order between linux and osx
-m2=$(cut -f1,4- outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase | md5sum | cut -f1 -d" ")
+m2=$(cut -f1,4- outdir/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")
 test $m2 == 70c907df8a996d2b3ba3f06fb942b244

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,8 +15,7 @@ m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools 
 test $m == be2dbe2f5a2ab660a949e1944e077a79
 
 # Test phasing
-snakemake --configfile tests/test_config.yaml outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase \
-    outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf
+snakemake --configfile tests/test_config.yaml outdir/phasing_stats.txt
 
 m2=$(md5sum outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase | cut -f1 -d" ")
 test $m2 == 5959009bb88bee382932a4080954cdb3

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,5 +11,12 @@ ln -s $PWD/testdata/reads.2.fastq.gz outdir/reads.2.fastq.gz
 snakemake --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
     outdir/reads.2.final.fastq.gz
 
-m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
-test $m == 02595541aa2247266537cd772d712820
+m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
+test $m == be2dbe2f5a2ab660a949e1944e077a79
+
+# Test phasing
+snakemake --configfile tests/test_config.yaml outdir/mapped.sorted.tag.rmdup.x2.filt.phase \
+    outdir/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf
+
+m2=$(md5sum outdir/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf | cut -f1 -d" ")
+test $m2 == deaa1f8820fdd0d75fd358fffa0bb4ec

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,8 +15,8 @@ m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools 
 test $m == be2dbe2f5a2ab660a949e1944e077a79
 
 # Test phasing
-snakemake --configfile tests/test_config.yaml outdir/mapped.sorted.tag.rmdup.x2.filt.phase \
-    outdir/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf
+snakemake --configfile tests/test_config.yaml outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase \
+    outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf
 
-m2=$(md5sum outdir/mapped.sorted.tag.rmdup.x2.filt.phase.phased.vcf | cut -f1 -d" ")
+m2=$(md5sum outdir/mapped.sorted.tag.mkdup.bcmerge.filt.phase.phased.vcf | cut -f1 -d" ")
 test $m2 == deaa1f8820fdd0d75fd358fffa0bb4ec

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,7 +12,7 @@ snakemake -p --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
     outdir/reads.2.final.fastq.gz
 
 m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
-test $m == be2dbe2f5a2ab660a949e1944e077a79
+test $m == 53df30b14f6cc184758a4711f08daf43
 
 # Test phasing
 snakemake -p --configfile tests/test_config.yaml outdir/phasing_stats.txt

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,6 +6,7 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
 bowtie2_reference: ./testdata/chr1mini
 picard_command: picard
+hapcut2: . #Path to Hapcut2 command.
 call_variants: true # Call variants for dataset, this means that reference variants will not be used.
 reference_variants: . # Path to reference variants
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -7,6 +7,6 @@ sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' 
 bowtie2_reference: ./testdata/chr1mini
 picard_command: picard
 hapcut2: HapCUT2 #Path to Hapcut2 command.
-call_variants: true # Call variants for dataset, this means that reference variants will not be used.
-reference_variants: . # Path to reference variants
+call_variants: false # Call variants for dataset, this means that reference variants will not be used.
+reference_variants: ./testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,7 +6,11 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
 bowtie2_reference: ./testdata/chr1mini
 picard_command: picard
+
+####################
+# Phasing settings #
+####################
 hapcut2: HapCUT2 #Path to Hapcut2 command.
 call_variants: false # Call variants for dataset, this means that reference variants will not be used.
 reference_variants: ./testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants
-
+phasing_ground_truth: ./testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf #Path to phased variants used for calculating stats

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,7 +6,7 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
 bowtie2_reference: ./testdata/chr1mini
 picard_command: picard
-hapcut2: . #Path to Hapcut2 command.
+hapcut2: HapCUT2 #Path to Hapcut2 command.
 call_variants: true # Call variants for dataset, this means that reference variants will not be used.
 reference_variants: . # Path to reference variants
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,3 +6,6 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
 bowtie2_reference: ./testdata/chr1mini
 picard_command: picard
+call_variants: true # Call variants for dataset, this means that reference variants will not be used.
+reference_variants: . # Path to reference variants
+

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -11,6 +11,5 @@ picard_command: picard
 # Phasing settings #
 ####################
 hapcut2: HapCUT2 #Path to Hapcut2 command.
-call_variants: false # Call variants for dataset, this means that reference variants will not be used.
-reference_variants: ./testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants
+reference_variants: ./testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants, if not provided then variant will be called by freebayes
 phasing_ground_truth: ./testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf #Path to phased variants used for calculating stats

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,6 +1,6 @@
 index_nucleotides: 1
 heap_space: 3
-cluster_tag: BC    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
+cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini


### PR DESCRIPTION
This is the initial work on the phasing pipeline. I have used [HapCUT2](https://github.com/vibansal/HapCUT2) for phasing according to the [10x Genomics linked-reads protocol](https://github.com/vibansal/HapCUT2#10x-genomics-linked-reads). Hapcut2 is currently being installed through a bash script `install-hapcut2.sh` as no conda release is available. 

For reference VCF file I have included two option so far. Either you can call variants using [freebayes](https://github.com/ekg/freebayes) or used a high confidence set. For the tests runs I have been using a high confidence set from [GIAB for HG002_NA24385 genome](https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh38/supplementaryFiles/) which we have used for the testdata. This means that I have also updated the current testdata to `blr-testdata-0.2`. 

Other changes included:
- Changed from BC to BX for barcode tag (this is required for HapCUT2)
- Rule for checking phased vcf against "ground truth" phased vcf which is also provided as test data. 
 - Output from filterclusters  is now indexed as this is needed for LinkFragments script in HapCUT2 phasing.  