### PR TITLE
Make all rules in the Snakefile relative to the analysis folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Create soft links for the gzipped fastq files to analyze in the `workdir` folder
     ln -s $PWD/path/to/sample.R2.fastq.gz workdir/reads.2.fastq.gz
 
 Make a copy of the `config.yaml` file and enter the path to your reference genome.
-  
-    cp config.yaml workdir/my_config.yaml
-    
+
+    cp config.yaml workdir/
+
 Activate your enviroment
 
     conda activate blr
 
-Run the pipeline using snakemake and indicate your intended target. In this example the full pipeline is run.  
+Change into the `workdir` folder, and run the pipeline using snakemake, indicating your intended target. In this example, the full pipeline is run.
 
-    snakemake --snakefile path/to/Snakefile --configfile workdir/my_config.yaml workdir/reads.1.final.fastq.gz workdir/reads.2.final.fastq.gz 
+    snakemake --snakefile path/to/Snakefile reads.1.final.fastq.gz reads.2.final.fastq.gz
 
 ## Install and Setup
 

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -2,11 +2,11 @@ HAPCUT2=config["hapcut2"]
 
 rule hapcut2_extracthairs:
     output:
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
+        unlinked = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
     input:
-        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
-        vcf = "{dir}/reference.vcf"
-    log: "{dir}/hapcut2_extracthairs.log"
+        bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
+        vcf = "reference.vcf"
+    log: "hapcut2_extracthairs.log"
     shell:
          "{HAPCUT2}/build/extractHAIRS"
          " --10X 1"
@@ -16,12 +16,12 @@ rule hapcut2_extracthairs:
 
 rule hapcut2_linkfragments:
     output:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt"
+        linked = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt"
     input:
-        bam = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
-        vcf = "{dir}/reference.vcf",
-        unlinked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
-    log: "{dir}/hapcut2_linkfragments.log"
+        bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam",
+        vcf = "reference.vcf",
+        unlinked = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.unlinked.txt"
+    log: "hapcut2_linkfragments.log"
     shell:
          "python {HAPCUT2}/utilities/LinkFragments.py"
          " --bam {input.bam}"
@@ -31,12 +31,12 @@ rule hapcut2_linkfragments:
 
 rule hapcut2_phasing:
     output:
-        phase =      "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase",
-        phased_vcf = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF"
+        phase =      "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase",
+        phased_vcf = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF"
     input:
-        linked = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt",
-        vcf = "{dir}/reference.vcf"
-    log: "{dir}/hapcut2_phasing.log"
+        linked = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.linked.txt",
+        vcf = "reference.vcf"
+    log: "hapcut2_phasing.log"
     shell:
          "{HAPCUT2}/build/HAPCUT2"
          " --nf 1"
@@ -47,9 +47,9 @@ rule hapcut2_phasing:
 
 rule hapcut2_stats:
     output:
-        stats = "{dir}/phasing_stats.txt"
+        stats = "phasing_stats.txt"
     input:
-         vcf1 = "{dir}/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF",
+         vcf1 = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF",
     params:
           vcf2 = config["phasing_ground_truth"]
     shell:

--- a/rules/trim.smk
+++ b/rules/trim.smk
@@ -9,14 +9,14 @@ rule trim:
     # Cut 3' TES' sequence from R1 and R2. TES'=CTGTCTCTTATACACATCT
     # Discard untrimmed.
     output:
-        r1_fastq="{dir}/trimmed-c.1.fastq.gz",
-        r2_fastq="{dir}/trimmed-c.2.fastq.gz"
+        r1_fastq="trimmed-c.1.fastq.gz",
+        r2_fastq="trimmed-c.2.fastq.gz"
     input:
-        r1_fastq="{dir}/reads.1.fastq.gz",
-        r2_fastq="{dir}/reads.2.fastq.gz"
+        r1_fastq="reads.1.fastq.gz",
+        r2_fastq="reads.2.fastq.gz"
     log:
-        a = "{dir}/trimmed-a.log",
-        b = "{dir}/trimmed-b.log"
+        a = "trimmed-a.log",
+        b = "trimmed-b.log"
     threads: 20
     shell:
         "cutadapt" #Initial trim

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,16 +7,16 @@ rm -rf outdir
 mkdir -p outdir
 ln -s $PWD/testdata/reads.1.fastq.gz outdir/reads.1.fastq.gz
 ln -s $PWD/testdata/reads.2.fastq.gz outdir/reads.2.fastq.gz
+cp tests/test_config.yaml outdir/config.yaml
+cd outdir
+snakemake -s ../Snakefile -p reads.1.final.fastq.gz reads.2.final.fastq.gz
 
-snakemake -p --configfile tests/test_config.yaml outdir/reads.1.final.fastq.gz \
-    outdir/reads.2.final.fastq.gz
-
-m=$(samtools sort -n outdir/mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
+m=$(samtools sort -n mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
 test $m == 134db15680443fc32d25ba577a0c5700
 
 # Test phasing
-snakemake -p --configfile tests/test_config.yaml outdir/phasing_stats.txt
+snakemake -s ../Snakefile -p phasing_stats.txt
 
 # Cut away columns 2 and 3 as these change order between linux and osx
-m2=$(cut -f1,4- outdir/mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")
+m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")
 test $m2 == 70c907df8a996d2b3ba3f06fb942b244

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -4,12 +4,12 @@ cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x g
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
-bowtie2_reference: ./testdata/chr1mini
+bowtie2_reference: ../testdata/chr1mini
 picard_command: picard
 
 ####################
 # Phasing settings #
 ####################
-hapcut2: HapCUT2 #Path to Hapcut2 command.
-reference_variants: ./testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants, if not provided then variant will be called by freebayes
-phasing_ground_truth: ./testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf #Path to phased variants used for calculating stats
+hapcut2: ../HapCUT2 #Path to Hapcut2 command.
+reference_variants: ../testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf # Path to reference variants, if not provided then variant will be called by freebayes
+phasing_ground_truth: ../testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf #Path to phased variants used for calculating stats


### PR DESCRIPTION
That is, remove the {dir}/ prefix from all inputs and outputs.

Also, a config.yaml file is now expected to be in the analysis folder, and
the --configfile my_config.yaml option should no longer be provided.

Close #88