### PR TITLE
Add a couple of missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup(
     license="MIT",
     python_requires=">=3.6",
     install_requires=[
+        "pysam",
+        "dnaio",
+        "tqdm",
+        "snakemake",
         "importlib_resources; python_version<'3.7'",
     ],
     package_dir={"": "src"},


### PR DESCRIPTION
We may want to decide to not use `install_requires` at all since we need to manage dependencies through Conda anyway, but until then, we should keep this list up to date.