### PR TITLE
Run Bowtie with --reorder

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -101,6 +101,7 @@ rule bowtie2_mapping:
     log: "bowtie2_mapping.log"
     shell:
         "bowtie2"
+        " --reorder"
         " -1 {input.r1_fastq}"
         " -2 {input.r2_fastq}"
         " -x {params.reference}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,8 +19,8 @@ cp tests/test_config.yaml outdir/config.yaml
 cd outdir
 blr run reads.1.final.fastq.gz reads.2.final.fastq.gz
 
-m=$(samtools sort -n mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | samtools view - | md5sum | cut -f1 -d" ")
-test $m == 134db15680443fc32d25ba577a0c5700
+m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
+test $m == 19022e7b4faebc24459bc243dc837ef4
 
 # Test phasing
 blr run phasing_stats.txt


### PR DESCRIPTION
This ensures that the order of records in Bowtie’s output is the same as the
order of reads in the input FASTQ files.  Without this, the order is more or
less random and we cannot rely on it in the tests.

Closes #101