### PR TITLE
Run flake8 as part of CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
-language: python
+language: generic
 
 dist: xenial
 
 cache:
   directories:
     - $HOME/.cache/pip
-
-python:
-  - "3.6"
-os:
-  - linux
-  - osx
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
@@ -37,7 +31,13 @@ script:
 
 jobs:
   include:
+    - name: Linux
+      os: linux
+    - name: macOS
+      os: osx
     - name: flake8
+      language: python
+      python: "3.6"
       before_install:
       install: python3 -m pip install flake8
       script: flake8 src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,9 @@ cache:
 
 python:
   - "3.6"
-
-matrix:
-  include:
-    - os: osx
-      language: generic
-    - os: linux
+os:
+  - linux
+  - osx
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
@@ -35,4 +32,12 @@ install:
   - pip install .
   - bash install-hapcut2.sh
 
-script: tests/run.sh
+script:
+  - tests/run.sh
+
+jobs:
+  include:
+    - name: flake8
+      before_install:
+      install: python3 -m pip install flake8
+      script: flake8 src/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
         "snakemake",
         "importlib_resources; python_version<'3.7'",
     ],
+    extras_require={
+        "dev": ["flake8"],
+    },
     package_dir={"": "src"},
     packages=find_namespace_packages("src"),
     package_data={"blr": ["Snakefile", "rules/*.smk", "config.schema.yaml"]},

--- a/src/blr/cli/cdhitprep.py
+++ b/src/blr/cli/cdhitprep.py
@@ -2,7 +2,6 @@
 Take trimmed read barcodes sequences from headers (@HEADER_bc-seq)
 and write FASTA files with unique barcodes
 """
-import sys
 import os
 import logging
 
@@ -14,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 def main(args):
-    """Takes a fastq file barcode sequences in the header and writes a barcode fasta file with only unique entries. """
+    """
+    Takes a fastq file barcode sequences in the header and writes a barcode
+    fasta file with only unique entries.
+    """
 
     logger.info(f'Filtering barcodes with less than {args.filter} reads')
 

--- a/src/blr/cli/extractbarcode.py
+++ b/src/blr/cli/extractbarcode.py
@@ -51,16 +51,20 @@ def main(args):
 
 
 def add_arguments(parser):
-    parser.add_argument("input1", metavar='<INPUT FASTQ1>',
-                        help="Input .fastq file. Assumes to contain read1 if given with second input file. If only "
-                             "input1 is given, input is assumed to be an interleaved fastq file. If reading from stdin"
-                             "is requested use '-' as a placeholder.")
-    parser.add_argument("input2", nargs='?', metavar='<INPUT FASTQ2>',
-                        help="Input .fastq file for read2 for paired-end read. Leave empty if using interleaved fastq.")
-    parser.add_argument("-o1", "--output1", default=None, metavar='<OUTPUT FASTQ1>',
-                        help="Output .fastq file name for read1. If not specified the result is written to stdout"
-                             " as interleaved fastq. If output1 given but not output2, output will be written as "
-                             "interleaved fastq to output1.")
-    parser.add_argument("-o2", "--output2", default=None, metavar='<OUTPUT FASTQ2>',
-                        help="Output .fastq file name for read2. If not specified but -o1 given the result is written"
-                             " as interleaved fastq to o1.")
+    parser.add_argument(
+        "input1", metavar='<INPUT FASTQ1>',
+        help="Input .fastq file. Assumes to contain read1 if given with second input file. If only "
+             "input1 is given, input is assumed to be an interleaved fastq file. If reading from stdin"
+             "is requested use '-' as a placeholder.")
+    parser.add_argument(
+        "input2", nargs='?', metavar='<INPUT FASTQ2>',
+        help="Input .fastq file for read2 for paired-end read. Leave empty if using interleaved fastq.")
+    parser.add_argument(
+        "-o1", "--output1", default=None, metavar='<OUTPUT FASTQ1>',
+        help="Output .fastq file name for read1. If not specified the result is written to stdout"
+             " as interleaved fastq. If output1 given but not output2, output will be written as "
+             "interleaved fastq to output1.")
+    parser.add_argument(
+        "-o2", "--output2", default=None, metavar='<OUTPUT FASTQ2>',
+        help="Output .fastq file name for read2. If not specified but -o1 given the result is written"
+             " as interleaved fastq to o1.")

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -80,4 +80,3 @@ def add_arguments(parser):
     parser.add_argument("-bc", "--barcode-cluster-tag", metavar="<STRING>", type=str, default="BX",
                         help="Bam file tag where barcode cluster id is stored. 10x genomics longranger output "
                              "uses 'BX' for their error corrected barcodes. DEFAULT: BX")
-


### PR DESCRIPTION
This will run flake8 (a Python style checker) as part of the Continuous Integration tests. This tool finds things such as unused imports and variables or too long lines. This PR also fixes all the things it complains about. In the flake8 configuration, I’ve set the maximum line length to 119 in order to avoid having to reformat too much. This is a bit high in my opinion, and I’d prefer something around 100 or 90, but we can discuss this at a later time.