### PR TITLE
Add missing importlib_resources dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - conda env create -n testenv -f environment.${TRAVIS_OS_NAME}.lock.yml
   - conda activate testenv
-  - pip install .
+  - pip install --no-deps .
   - bash install-hapcut2.sh
 
 script:

--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -31,6 +31,7 @@ dependencies:
   - htslib=1.9=ha228f0b_7
   - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
+  - importlib_resources=1.0.2=py36_1000
   - jpeg=9c=h14c3975_1001
   - jsonschema=3.0.2=py36_0
   - krb5=1.16.3=h05b26f9_1001
@@ -86,7 +87,7 @@ dependencies:
   - tbb=2019.8=hc9558a2_0
   - tk=8.6.9=hed695b0_1003
   - tqdm=4.36.1=py_0
-  - urllib3=1.25.5=py36_0
+  - urllib3=1.25.6=py36_0
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h516909a_0
   - xopen=0.8.2=py36_0

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -25,6 +25,7 @@ dependencies:
   - gitpython=3.0.2=py_0
   - htslib=1.9=h3a161e8_7
   - idna=2.8=py36_1000
+  - importlib_resources=1.0.2=py36_1000
   - jsonschema=3.0.2=py36_0
   - krb5=1.16.3=hcfa6398_1001
   - libblas=3.8.0=12_openblas
@@ -70,7 +71,7 @@ dependencies:
   - tbb=2019.8=h770b8ee_0
   - tk=8.6.9=h2573ce8_1003
   - tqdm=4.36.1=py_0
-  - urllib3=1.25.5=py36_0
+  - urllib3=1.25.6=py36_0
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h01d97ff_0
   - xopen=0.8.2=py36_0

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - samtools
   - snakemake-minimal
   - tqdm
+  - importlib_resources


### PR DESCRIPTION
This was missing from the Conda dependencies.

This was not caught on Travis because we run "pip install ." there, which
will install the missing dependency as it is listed in install_requires in
setup.py.  To catch the error, we now use "pip install --no-deps ." instead.