### PR TITLE
Changed kmer length for cd-hit to improve runtime.

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -76,7 +76,7 @@ rule barcode_clustering:
         " -c 0.9"
         " -gap 100"
         " -g 1"
-        " -n 3"
+        " -n 8"
         " -M 0 >> {log}"
 
 rule concat_files:


### PR DESCRIPTION
Related to #21.

Updated kmer length from 3 to 8. After some test this showed to improve runtime while not changing clustering output.

Run test clustering on FASTA containing 3,898,552 st unique barcodes (corresponding to the largest indexed FASTA TTT.fa from a run on XVII.SM10_10x.3x.R1.fastq.gz and XVII.SM10_10x.3x.R2.fastq.gz)

Test was performed with 20 cores on uppmax and three times each with the different settings

**Runtime for n=3: **

real    109m32.949s, 108m36.658s, 108m37.740s
user   2177m6.753s, 2156m23.161s, 2158m46.229s
sys     0m28.632s, 0m30.148s, 0m28.183s

**Runtime for n=8**

real    1m30.728s, 1m31.669s, 1m32.015s
user    24m53.959s, 25m5.823s, 24m59.359s
sys     0m20.585s,  0m16.851s, 0m21.683s

This corresponds to a user time reduction from ~35 h to ~25 min for a single file! 

Comparing the output .clstr files showed no difference in clustering between the two settings. 
