### PR TITLE
Allow to choose BWA-MEM instead of Bowtie2 as read mapper

### DIFF
--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -10,6 +10,7 @@ dependencies:
   - attrs=19.1.0=py_0
   - blas=2.12=openblas
   - bowtie2=2.3.5=py36he860b03_0
+  - bwa=0.7.17=hed695b0_6
   - bzip2=1.0.8=h516909a_1
   - ca-certificates=2019.9.11=hecc5488_0
   - cd-hit=4.8.1=hdbcaa40_2

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -8,6 +8,7 @@ dependencies:
   - attrs=19.1.0=py_0
   - blas=2.12=openblas
   - bowtie2=2.3.5=py36h5c9b4e4_0
+  - bwa=0.7.17=h2573ce8_6
   - bzip2=1.0.8=h01d97ff_1
   - ca-certificates=2019.9.11=hecc5488_0
   - cd-hit=4.8.1=hd9629dc_2

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - nomkl
   - python=3.6
   - bowtie2
+  - bwa
   - pysam
   - picard=2.10
   - cd-hit

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -96,26 +96,38 @@ rule concat_files:
         "cat {input} > {output}"
 
 
-rule bowtie2_mapping:
-    # Mapping of trimmed FASTQ to reference using bowtie2 and sorting output using samtools.
+rule map_reads:
     output:
         bam = "mapped.sorted.bam"
     input:
         r1_fastq = "trimmed-c.1.fastq.gz",
         r2_fastq = "trimmed-c.2.fastq.gz"
     threads: 20
-    log: "bowtie2_mapping.log"
-    shell:
-        "bowtie2"
-        " --reorder"
-        " -1 {input.r1_fastq}"
-        " -2 {input.r2_fastq}"
-        " -x {config[bowtie2_reference]}"
-        " --maxins 2000"
-        " -p {threads} 2> {log} |"
-        "samtools sort -"
-        " -@ {threads}"
-        " -O BAM > {output.bam}"
+    log: "read_mapping.log"
+    run:
+        commands = {
+            "bwa":
+                "bwa mem"
+                " -t {threads}"
+                " {config[genome_reference]}"
+                " {input.r1_fastq}"
+                " {input.r2_fastq}",
+            "bowtie2":
+                "bowtie2"
+                " -p {threads}"
+                " --reorder"
+                " --maxins 2000"
+                " -x {config[genome_reference]}"
+                " -1 {input.r1_fastq}"
+                " -2 {input.r2_fastq}"
+        }
+        command = commands[config["read_mapper"]].format(**locals(), **globals())
+        shell(
+            "{command} 2> {log} |"
+            "samtools sort -"
+            " -@ {threads}"
+            " -O BAM > {output.bam}"
+        )
 
 
 rule tagbam:

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -104,15 +104,13 @@ rule bowtie2_mapping:
         r1_fastq = "trimmed-c.1.fastq.gz",
         r2_fastq = "trimmed-c.2.fastq.gz"
     threads: 20
-    params:
-        reference = config["bowtie2_reference"]
     log: "bowtie2_mapping.log"
     shell:
         "bowtie2"
         " --reorder"
         " -1 {input.r1_fastq}"
         " -2 {input.r2_fastq}"
-        " -x {params.reference}"
+        " -x {config[bowtie2_reference]}"
         " --maxins 2000"
         " -p {threads} 2> {log} |"
         "samtools sort -"
@@ -144,11 +142,8 @@ rule mark_duplicates:
     log:
         metrics = "picard_mkdup_metrics.log",
         stderr = "picard_mkdup.log"
-    params:
-        picard_command = config["picard_command"],
-        heap_space=config["heap_space"]
     shell:
-        "{params.picard_command} -Xms{params.heap_space}g MarkDuplicates"
+        "{config[picard_command]} -Xms{config[heap_space]}g MarkDuplicates"
         " I={input.bam}"
         " O={output.bam}"
         " M={log.metrics}"
@@ -216,23 +211,18 @@ rule bam_to_fastq:
     input:
         bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam"
     log: "picard_samtofastq.log"
-    params:
-        picard_command = config["picard_command"],
-        heap_space=config["heap_space"]
     shell:
-        "{params.picard_command} -Xms{params.heap_space}g SamToFastq"
+        "{config[picard_command]} -Xms{config[heap_space]}g SamToFastq"
         " I={input.bam}"
         " FASTQ={output.r1_fastq}"
         " SECOND_END_FASTQ={output.r2_fastq} 2>> {log}"
 
 
-if config['reference_variants']:
+if config["reference_variants"]:
     rule link:
         output: "reference.vcf"
-        params: config['reference_variants']
-        run:
-            cmd = "ln -s " + os.path.abspath(config['reference_variants']) + " " + str(output)
-            shell(cmd)
+        shell:
+            "ln -s {config[reference_variants]} {output}"
 else:
     rule call_variants_freebayes:
         output:
@@ -240,9 +230,7 @@ else:
         input:
              bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam"
         log: "call_variants_freebayes.log"
-        params:
-            reference = config["bowtie2_reference"] + ".fasta" # I am unsure if this is a good solution, but it works.
         shell:
              "freebayes"
-             " -f {params.reference}"
+             " -f {config[reference]}.fasta"
              " {input.bam} 1> {output.vcf} 2> {log}"

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -4,8 +4,9 @@ cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x g
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
-bowtie2_reference: #Fill in /path/to/bowtie2_reference
+genome_reference:  # Path to indexed reference
 picard_command: picard #Picard run command.
+read_mapper: bowtie2  # Choose bwa or bowtie2
 
 ####################
 # Phasing settings #

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -25,9 +25,13 @@ properties:
     type: string
     description: SAM tag to use for store original barcode sequence in bam file. 'RX' is 10x genomic default
     default: RX
-  bowtie2_reference:
+  read_mapper:
+    type: string
+    pattern: "bwa|bowtie2"
+    description: Which read mapper to use
+  genome_reference:
     type: [ "string", "null" ]
-    description: Path to bowtie2 reference for mapping
+    description: Reference index prefix
   picard_command:
     type: string
     description: Picard command to be used.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,7 +14,6 @@ blr --version
 rm -rf outdir-bwa
 blr init --r1=testdata/reads.1.fastq.gz outdir-bwa
 sed 's|read_mapper: .*|read_mapper: bwa|' tests/test_config.yaml > outdir-bwa/blr.yaml
-#echo "genome_reference:
 
 pushd outdir-bwa
 blr run

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,14 +9,26 @@ cd-hit --help | head -n 1 || true
 snakemake --version
 blr --version
 
-( cd testdata && bowtie2-build chr1mini.fasta chr1mini > /dev/null )
+( cd testdata && bwa index chr1mini.fasta )
 
-rm -rf outdir
-blr init --r1=testdata/reads.1.fastq.gz outdir
-cp tests/test_config.yaml outdir/blr.yaml
-cd outdir
+rm -rf outdir-bwa
+blr init --r1=testdata/reads.1.fastq.gz outdir-bwa
+sed 's|read_mapper: .*|read_mapper: bwa|' tests/test_config.yaml > outdir-bwa/blr.yaml
+#echo "genome_reference:
+
+pushd outdir-bwa
 blr run
+m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
+test $m == 55c9c63d3d371fbff6f99977c57cd7a6
+popd
 
+( cd testdata && bowtie2-build chr1mini.fasta chr1mini.fasta > /dev/null )
+
+rm -rf outdir-bowtie2
+blr init --r1=testdata/reads.1.fastq.gz outdir-bowtie2
+cp tests/test_config.yaml outdir-bowtie2/blr.yaml
+pushd outdir-bowtie2
+blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
 test $m == 827612d1dd59d07071defa26bc8add4c
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -3,9 +3,10 @@ heap_space: 3
 cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x genomic default
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
-sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic defaultbowtie2_reference: /Users/pontus.hojer/projects/BLR/testdata/chr1mini
-bowtie2_reference: ../testdata/chr1mini
+sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 picard_command: picard
+read_mapper: bowtie2
+genome_reference: ../testdata/chr1mini.fasta
 
 ####################
 # Phasing settings #


### PR DESCRIPTION
This introduces a new configuration setting named `read_mapper` and
also renames the `bowtie2_reference` setting to `genome_reference`.

Run times when mapping 20 million read pairs (repeated three times):

* Bowtie2: 43m 33s, 43m 27s, 43m 22s
* BWA-MEM: 33m 23s, 33m 30s, 33m 31s

Looking at these numbers, we should probably change the default mapper, but I haven’t done so in this PR.

I’ve also added a commit that removes usage of `params` when the only purpose is to assign `config["key"]` to a variable which can the be used within a shell command. In those cases, `{config[key]}` can be used directly instead.

*Note*: This will probably need to be rebased once #109 is merged.