### PR TITLE
Updated barcode information handling 

### DIFF
--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -6,56 +6,58 @@ dependencies:
   - _libgcc_mutex=0.1=main
   - alsa-lib=1.1.5=h516909a_1001
   - appdirs=1.4.3=py_1
-  - asn1crypto=0.24.0=py36_1003
-  - attrs=19.2.0=py_0
-  - blas=2.12=openblas
+  - asn1crypto=1.2.0=py36_0
+  - attrs=19.3.0=py_0
+  - blas=2.14=openblas
   - bowtie2=2.3.5=py36he860b03_0
   - bwa=0.7.17=hed695b0_6
   - bzip2=1.0.8=h516909a_1
   - ca-certificates=2019.9.11=hecc5488_0
   - certifi=2019.9.11=py36_0
-  - cffi=1.12.3=py36h8022711_0
+  - cffi=1.13.1=py36h8022711_0
   - chardet=3.0.4=py36_1003
   - configargparse=0.13.0=py_1
   - cryptography=2.7=py36h72c5cf5_0
   - curl=7.65.3=hf8cf82a_0
   - cutadapt=2.5=py36h516909a_0
   - datrie=0.8=py36h516909a_0
-  - dnaio=0.3=py36h14c3975_1
+  - dnaio=0.4=py36h516909a_0
   - docutils=0.15.2=py36_0
   - fontconfig=2.13.1=h86ecdb6_1001
   - freetype=2.10.0=he983fc9_1
   - giflib=5.1.7=h516909a_1
   - gitdb2=2.0.6=py_0
-  - gitpython=3.0.2=py_0
+  - gitpython=3.0.4=py_0
   - htslib=1.9=ha228f0b_7
   - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
+  - importlib_metadata=0.23=py36_0
   - importlib_resources=1.0.2=py36_1000
   - jpeg=9c=h14c3975_1001
-  - jsonschema=3.0.2=py36_0
+  - jsonschema=3.1.1=py36_0
   - krb5=1.16.3=h05b26f9_1001
   - lcms2=2.9=h2e4bb80_0
-  - libblas=3.8.0=12_openblas
-  - libcblas=3.8.0=12_openblas
+  - libblas=3.8.0=14_openblas
+  - libcblas=3.8.0=14_openblas
   - libcurl=7.65.3=hda55be3_0
   - libdeflate=1.0=h14c3975_1
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
-  - libgfortran-ng=7.3.0=hdf63c60_0
+  - libgfortran-ng=7.3.0=hdf63c60_2
   - libiconv=1.15=h516909a_1005
-  - liblapack=3.8.0=12_openblas
-  - liblapacke=3.8.0=12_openblas
-  - libopenblas=0.3.7=h6e990d7_1
+  - liblapack=3.8.0=14_openblas
+  - liblapacke=3.8.0=14_openblas
+  - libopenblas=0.3.7=h6e990d7_2
   - libpng=1.6.37=hed695b0_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.1.0=hdf63c60_0
-  - libtiff=4.0.10=h57b8799_1003
+  - libtiff=4.0.10=hfc65ed5_1004
   - libuuid=2.32.1=h14c3975_1000
   - libxcb=1.13=h14c3975_1002
   - libxml2=2.9.9=hee79883_5
   - lz4-c=1.8.3=he1b5a44_1001
+  - more-itertools=7.2.0=py_0
   - ncurses=6.1=hf484d3e_1002
   - nomkl=3.0=0
   - openjdk=11.0.1=h46a85a0_1017
@@ -63,7 +65,7 @@ dependencies:
   - perl=5.26.2=h516909a_1006
   - picard=2.10.6=py36_0
   - pigz=2.3.4=0
-  - pip=19.2.3=py36_0
+  - pip=19.3.1=py36_0
   - psutil=5.6.3=py36h516909a_0
   - pthread-stubs=0.4=h14c3975_1001
   - pycparser=2.19=py36_1
@@ -77,23 +79,23 @@ dependencies:
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py36_1
   - samtools=1.9=h10a08f8_12
-  - setuptools=41.2.0=py36_0
+  - setuptools=41.4.0=py36_0
   - six=1.12.0=py36_1000
   - smmap2=2.0.5=py_0
-  - snakemake-minimal=5.6.0=py_0
-  - sqlite=3.29.0=hcee41ef_1
+  - snakemake-minimal=5.7.4=py_0
+  - sqlite=3.30.1=hcee41ef_0
   - starcode=1.3=h14c3975_1
-  - tbb=2019.8=hc9558a2_0
+  - tbb=2019.9=hc9558a2_0
   - tk=8.6.9=hed695b0_1003
   - tqdm=4.36.1=py_0
   - urllib3=1.25.6=py36_0
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h516909a_0
-  - xopen=0.8.2=py36_0
+  - xopen=0.8.3=py36_0
   - xorg-fixesproto=5.0=h14c3975_1002
   - xorg-inputproto=2.3.2=h14c3975_1002
   - xorg-kbproto=1.0.7=h14c3975_1002
-  - xorg-libx11=1.6.8=h516909a_0
+  - xorg-libx11=1.6.9=h516909a_0
   - xorg-libxau=1.0.9=h14c3975_0
   - xorg-libxdmcp=1.1.3=h516909a_0
   - xorg-libxext=1.3.4=h516909a_0
@@ -107,6 +109,7 @@ dependencies:
   - xorg-xproto=7.0.31=h14c3975_1007
   - xz=5.2.4=h14c3975_1001
   - yaml=0.1.7=h14c3975_1001
+  - zipp=0.6.0=py_0
   - zlib=1.2.11=h516909a_1006
-  - zstd=1.4.0=h3b9ef0a_0
+  - zstd=1.4.3=h3b9ef0a_0
 

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -4,43 +4,45 @@ channels:
   - defaults
 dependencies:
   - appdirs=1.4.3=py_1
-  - asn1crypto=0.24.0=py36_1003
-  - attrs=19.2.0=py_0
-  - blas=2.12=openblas
+  - asn1crypto=1.2.0=py36_0
+  - attrs=19.3.0=py_0
+  - blas=2.14=openblas
   - bowtie2=2.3.5=py36h5c9b4e4_0
   - bwa=0.7.17=h2573ce8_6
   - bzip2=1.0.8=h01d97ff_1
   - ca-certificates=2019.9.11=hecc5488_0
   - certifi=2019.6.16=py36_1
-  - cffi=1.12.3=py36hccf1714_0
+  - cffi=1.13.1=py36h33e799b_0
   - chardet=3.0.4=py36_1003
   - configargparse=0.13.0=py_1
   - cryptography=2.7=py36h212c5bf_0
   - curl=7.65.3=h22ea746_0
   - cutadapt=2.5=py36h01d97ff_0
   - datrie=0.8=py36h01d97ff_0
-  - dnaio=0.3=py36h1de35cc_1
+  - dnaio=0.4=py36h01d97ff_0
   - docutils=0.15.2=py36_0
   - gitdb2=2.0.6=py_0
-  - gitpython=3.0.2=py_0
+  - gitpython=3.0.4=py_0
   - htslib=1.9=h3a161e8_7
   - idna=2.8=py36_1000
+  - importlib_metadata=0.23=py36_0
   - importlib_resources=1.0.2=py36_1000
-  - jsonschema=3.0.2=py36_0
+  - jsonschema=3.1.1=py36_0
   - krb5=1.16.3=hcfa6398_1001
-  - libblas=3.8.0=12_openblas
-  - libcblas=3.8.0=12_openblas
+  - libblas=3.8.0=14_openblas
+  - libcblas=3.8.0=14_openblas
   - libcurl=7.65.3=h16faf7d_0
-  - libcxx=9.0.0=0
-  - libcxxabi=9.0.0=0
+  - libcxx=9.0.0=h89e68fa_1
   - libdeflate=1.0=h1de35cc_1
   - libedit=3.1.20170329=hcfe32e1_1001
   - libffi=3.2.1=h6de7cb9_1006
-  - libgfortran=3.0.1=0
-  - liblapack=3.8.0=12_openblas
-  - liblapacke=3.8.0=12_openblas
-  - libopenblas=0.3.7=hd44dcd8_1
+  - libgfortran=4.0.0=2
+  - liblapack=3.8.0=14_openblas
+  - liblapacke=3.8.0=14_openblas
+  - libopenblas=0.3.7=h4bb4525_2
   - libssh2=1.8.2=hcdc9a53_2
+  - llvm-openmp=9.0.0=h40edb58_0
+  - more-itertools=7.2.0=py_0
   - ncurses=6.1=h0a44026_1002
   - nomkl=3.0=0
   - openjdk=11.0.1=h01d97ff_1017
@@ -48,7 +50,7 @@ dependencies:
   - perl=5.26.2=haec8ef5_1006
   - picard=2.10.6=py36_0
   - pigz=2.3.4=0
-  - pip=19.2.3=py36_0
+  - pip=19.3.1=py36_0
   - psutil=5.6.3=py36h01d97ff_0
   - pycparser=2.19=py36_1
   - pyopenssl=19.0.0=py36_0
@@ -61,20 +63,21 @@ dependencies:
   - readline=8.0=hcfe32e1_0
   - requests=2.22.0=py36_1
   - samtools=1.9=h8aa4d43_12
-  - setuptools=41.2.0=py36_0
+  - setuptools=41.4.0=py36_0
   - six=1.12.0=py36_1000
   - smmap2=2.0.5=py_0
-  - snakemake-minimal=5.6.0=py_0
-  - sqlite=3.29.0=hb7d70f7_1
+  - snakemake-minimal=5.7.4=py_0
+  - sqlite=3.30.1=h93121df_0
   - starcode=1.3=h1de35cc_1
-  - tbb=2019.8=h770b8ee_0
+  - tbb=2019.9=ha1b3eb9_0
   - tk=8.6.9=h2573ce8_1003
   - tqdm=4.36.1=py_0
   - urllib3=1.25.6=py36_0
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h01d97ff_0
-  - xopen=0.8.2=py36_0
+  - xopen=0.8.3=py36_0
   - xz=5.2.4=h1de35cc_1001
   - yaml=0.1.7=h1de35cc_1001
-  - zlib=1.2.11=h01d97ff_1006
+  - zipp=0.6.0=py_0
+  - zlib=1.2.11=h0b31af3_1006
 

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -234,9 +234,9 @@ def seed_duplicates(merge_dict, cache_dup_pos, pos_new, bc_new, window):
 
 def find_min_bc(bc_minimum, merge_dict):
     """
-    Goes through merge dict and finds the alphabetically top string for a chain of key-value entries. E.g if merge_dict has
-    TAGA => GGAT, GGAT => CTGA, CTGA => ACGA it will return ACGA if any of the values CTGA, GGAT, TAGA or ACGA are given.
-    :return: lowest clstr id for key-value chain
+    Goes through merge dict and finds the alphabetically top string for a chain of key-value entries. E.g if
+    merge_dict has TAGA => GGAT, GGAT => CTGA, CTGA => ACGA it will return ACGA if any of the values CTGA, GGAT,
+    TAGA or ACGA are given. :return: lowest clstr id for key-value chain
     """
 
     while True:

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -107,15 +107,13 @@ def main(args):
 
             # If read barcode in merge dict, change tag and header to compensate.
             try:
-                previous_barcode_id = int(read.get_tag(args.barcode_tag))
+                previous_barcode_id = str(read.get_tag(args.barcode_tag))
             except KeyError:
                 previous_barcode_id = None
             if previous_barcode_id in merge_dict:
                 summary.reads_with_new_tag += 1
                 new_barcode_id = str(merge_dict[previous_barcode_id])
                 read.set_tag(args.barcode_tag, new_barcode_id, value_type="Z")
-                read.query_name = "_".join(
-                    read.query_name.split("_")[:-1]) + "_" + args.barcode_tag + ":Z:" + new_barcode_id
 
                 # Merge file writing
                 if new_barcode_id not in bc_seq_already_written:
@@ -148,7 +146,7 @@ def meet_requirements(read, mate, summary, barcode_tag):
         rp_meet_requirements = False
 
     try:
-        bc_new = int(read.get_tag(barcode_tag))
+        bc_new = str(read.get_tag(barcode_tag))
     except KeyError:
         summary.non_tagged_reads += 2
         rp_meet_requirements = False
@@ -236,8 +234,8 @@ def seed_duplicates(merge_dict, cache_dup_pos, pos_new, bc_new, window):
 
 def find_min_bc(bc_minimum, merge_dict):
     """
-    Goes through merge dict and finds the lowest current value for a chain of key-value entries. E.g if merge_dict has
-    100 => 80, 80 => 60, 60 => 40 it will return 40 if any of the values 100,80,60 or 40 are given.
+    Goes through merge dict and finds the alphabetically top string for a chain of key-value entries. E.g if merge_dict has
+    TAGA => GGAT, GGAT => CTGA, CTGA => ACGA it will return ACGA if any of the values CTGA, GGAT, TAGA or ACGA are given.
     :return: lowest clstr id for key-value chain
     """
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -57,8 +57,7 @@ def strip_barcode(pysam_read, tags_to_be_removed, summary):
     """
 
     # Modify header
-    header, bc_info = pysam_read.query_name.split("_", maxsplit=1)
-    pysam_read.query_name = f"{header}_FILTERED-{bc_info}"
+    pysam_read.query_name = f"{pysam_read.query_name}_FILTERED"
 
     # Remove tags
     for bam_tag in tags_to_be_removed:
@@ -68,7 +67,7 @@ def strip_barcode(pysam_read, tags_to_be_removed, summary):
         summary.reads_with_removed_tags += 1
 
         # Strip read from tag
-        pysam_read.set_tag(bam_tag, "FILTERED", value_type="Z")
+        pysam_read.set_tag(bam_tag, None, value_type="Z")
 
     return pysam_read, summary
 

--- a/src/blr/cli/tagfastq.py
+++ b/src/blr/cli/tagfastq.py
@@ -22,7 +22,6 @@ import logging
 import sys
 import dnaio
 from tqdm import tqdm
-from collections import namedtuple
 
 logger = logging.getLogger(__name__)
 

--- a/src/blr/cli/tagfastq.py
+++ b/src/blr/cli/tagfastq.py
@@ -52,6 +52,7 @@ def main(args):
     logger.info(f"Output detected as {'interleaved' if out_interleaved else 'paired'} FASTQ.")
 
     reads_missing_barcode = 0
+    separator = args.sep
     # Parse input FASTA/FASTQ for read1 and read2 and write output
     with dnaio.open(args.input1, file2=args.input2, interleaved=in_interleaved, mode="r") as reader, \
             dnaio.open(args.output1, file2=args.output2, interleaved=out_interleaved, mode="w") as writer:
@@ -73,7 +74,7 @@ def main(args):
                 corr_barcode_id = f"{args.barcode_tag}:Z:{corr_barcode_seq}"
 
                 # Create new name with barcode information.
-                new_name = "_".join([name_and_pos_r1, raw_barcode_id, corr_barcode_id])
+                new_name = separator.join([name_and_pos_r1, raw_barcode_id, corr_barcode_id])
 
                 # Save header to read instances
                 read1.name = " ".join([new_name, read_and_index_r1])
@@ -146,3 +147,7 @@ def add_arguments(parser):
     parser.add_argument(
         "-s", "--sequence-tag", default="RX",
         help="SAM tag for storing the raw barcode sequence. Default: %(default)s")
+    parser.add_argument(
+        "--sep", default="_",
+        help="Character used as separator for storing SAM tags in the FASTQ/FASTA header. Default: %(default)s"
+    )

--- a/src/blr/cli/tagfastq.py
+++ b/src/blr/cli/tagfastq.py
@@ -68,15 +68,17 @@ def main(args):
                 reads_missing_barcode += 1
 
             if raw_barcode_seq:
-                corr_barcode = corrected_barcodes[raw_barcode_seq]
+                corr_barcode_seq = corrected_barcodes[raw_barcode_seq]
 
-                # Make new string with barcode sequence and id to add to headers.
-                new_text = f"{corr_barcode.seq}_{args.sequence_tag}:Z:{raw_barcode_seq}" \
-                           f"_{args.barcode_tag}:Z:{corr_barcode.index}"
+                raw_barcode_id = f"{args.sequence_tag}:Z:{raw_barcode_seq}"
+                corr_barcode_id = f"{args.barcode_tag}:Z:{corr_barcode_seq}"
+
+                # Create new name with barcode information.
+                new_name = "_".join([name_and_pos_r1, raw_barcode_id, corr_barcode_id])
 
                 # Save header to read instances
-                read1.name = f"{name_and_pos_r1}_{new_text} {read_and_index_r1}"
-                read2.name = f"{name_and_pos_r2}_{new_text} {read_and_index_r2}"
+                read1.name = " ".join([new_name, read_and_index_r1])
+                read2.name = " ".join([new_name, read_and_index_r2])
 
             # Write to out
             writer.write(read1, read2)
@@ -91,15 +93,12 @@ def parse_corrected_barcodes(open_file):
     Parse starcode cluster output and return a dictionary with raw sequences pointing to a
     corrected canonical sequence
     :param open_file: starcode tabular output file.
-    :return: dict: raw sequences pointing to a nametuple containing corrected canonical
-    sequence and index.
+    :return: dict: raw sequences pointing to a corrected canonical sequence.
     """
-    target = namedtuple("Cluster", ['seq', 'index'])
     corrected_barcodes = dict()
-    for index, cluster in tqdm(enumerate(open_file.readlines(), start=1), desc="Clusters processed"):
+    for cluster in tqdm(open_file.readlines(), desc="Clusters processed"):
         canonical_seq, _, cluster_seqs = cluster.strip().split("\t", maxsplit=3)
-        cluster_target = target(seq=canonical_seq, index=index)
-        corrected_barcodes.update({raw_seq: cluster_target for raw_seq in cluster_seqs.split(",")})
+        corrected_barcodes.update({raw_seq: canonical_seq for raw_seq in cluster_seqs.split(",")})
     return corrected_barcodes
 
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ sed 's|read_mapper: .*|read_mapper: bwa|' tests/test_config.yaml > outdir-bwa/bl
 pushd outdir-bwa
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == b7bffb901d59030ea4cc939a29c85643
+test $m == dbdfa522fbf41b44049207bbeed3fea1
 
 popd
 
@@ -30,7 +30,7 @@ cp tests/test_config.yaml outdir-bowtie2/blr.yaml
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == 5607178a324ce4a394e5370a4d192377
+test $m == bfe1f589782a502a6b123e5edcbe9b3e
 
 # Test phasing
 blr run phasing_stats.txt


### PR DESCRIPTION
Updated barcode information handling in FASTQ and BAM files so that barcode strings can be handled. This is how barcodes are handled in 10x genomics data and contain more useful information than the integer representing the `cluster id` previously used. I also implemented some changes to handling of alignment/read headers and SAM tags. 


- `tagfastq` now tags reads with the corrected and raw barcode as SAM tags separated by undescore '_' e.g. `@ST:E00269:339:H27G2CCX2:7:1608_RX:Z:GGCGTAACTACGTTAGCTCG_BX:Z:GGCGTAACTACGTTAGCTCG 1:N:0:NGGCAGAA`. Reads without barcodes appear without these tags.
- `tagbam` transfers the tag information from the header to the designated SAM tags. Note that this now removed the info from the header.
- `clusterrmdup` now handles strings instead of integers. The sort function is used as previously to direct all duplicate connected clusters to the same final cluster.
- `filterclusters` now only appends "_FILTERED" to reads filtered out and removes the barcode tags rather than replacing them with the string "FILTERED". This is because the string "FILTERED" could be interpreted as a barcode in downstream analysis. Thus it feels safe to just remove it.
- Updated md5sum based on edits.

Issue #121