### PR TITLE
Start testing with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 install:
   - conda env create -n testenv -f environment.${TRAVIS_OS_NAME}.lock.yml
   - conda activate testenv
+  - conda install pytest
   - pip install --no-deps .
   - bash install-hapcut2.sh
 
@@ -40,4 +41,4 @@ jobs:
       python: "3.6"
       before_install:
       install: python3 -m pip install flake8
-      script: flake8 src/
+      script: flake8 src/ tests/

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -90,7 +90,7 @@ rule map_reads:
         }
         command = commands[config["read_mapper"]].format(**locals(), **globals())
         shell(
-            "{command} 2> {log} |"
+            "{command} 2> >(tee {log} >&2) |"
             "samtools sort -"
             " -@ {threads}"
             " -O BAM > {output.bam}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,17 +14,6 @@ blr --version
 
 pytest tests/
 
-rm -rf outdir-bwa
-blr init --r1=testdata/reads.1.fastq.gz outdir-bwa
-sed 's|read_mapper: .*|read_mapper: bwa|' tests/test_config.yaml > outdir-bwa/blr.yaml
-
-pushd outdir-bwa
-blr run
-m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == dbdfa522fbf41b44049207bbeed3fea1
-
-popd
-
 rm -rf outdir-bowtie2
 blr init --r1=testdata/reads.1.fastq.gz outdir-bowtie2
 cp tests/test_config.yaml outdir-bowtie2/blr.yaml

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,7 @@ snakemake --version
 blr --version
 
 ( cd testdata && bwa index chr1mini.fasta )
+( cd testdata && bowtie2-build chr1mini.fasta chr1mini.fasta > /dev/null )
 
 pytest tests/
 
@@ -23,8 +24,6 @@ m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f
 test $m == dbdfa522fbf41b44049207bbeed3fea1
 
 popd
-
-( cd testdata && bowtie2-build chr1mini.fasta chr1mini.fasta > /dev/null )
 
 rm -rf outdir-bowtie2
 blr init --r1=testdata/reads.1.fastq.gz outdir-bowtie2

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,6 +11,8 @@ blr --version
 
 ( cd testdata && bwa index chr1mini.fasta )
 
+pytest tests/
+
 rm -rf outdir-bwa
 blr init --r1=testdata/reads.1.fastq.gz outdir-bwa
 sed 's|read_mapper: .*|read_mapper: bwa|' tests/test_config.yaml > outdir-bwa/blr.yaml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,30 +1,58 @@
 from pathlib import Path
+import pysam
+import pytest
+from xopen import xopen
 
 from blr.cli.init import init
 from blr.cli.run import run
 
+TESTDATA_READS = Path("testdata/reads.1.fastq.gz")
 
-def copy_config(source, target, genome_reference=None):
-    """Copy config, possibly changing the genome_reference"""
+
+def count_bam_alignments(path):
+    with pysam.AlignmentFile(path) as af:
+        n = 0
+        for _ in af:
+            n += 1
+    return n
+
+
+def count_fastq_reads(path):
+    with xopen(path) as f:
+        n = 0
+        for _ in f:
+            n += 1
+    return n // 4
+
+
+def copy_config(source, target, genome_reference=None, read_mapper=None):
+    """Copy config, possibly changing genome_reference or read_mapper"""
 
     with open(source) as infile:
         with open(target, "w") as outfile:
             for line in infile:
                 if genome_reference is not None and line.startswith("genome_reference:"):
-                    line = "genome_reference: " + str(Path("testdata/chr1mini.fasta").absolute())
+                    path = Path("testdata/chr1mini.fasta").absolute()
+                    line = f"genome_reference: {path}\n"
+                if read_mapper is not None and line.startswith("read_mapper:"):
+                    line = f"read_mapper: {read_mapper}\n"
                 outfile.write(line)
 
 
 def test_init(tmpdir):
-    init(tmpdir / "analysis", Path("testdata/reads.1.fastq.gz"))
+    init(tmpdir / "analysis", TESTDATA_READS)
 
 
-def test_run(tmpdir):
+@pytest.mark.parametrize("read_mapper", ["bwa", "bowtie2"])
+def test_mappers(tmpdir, read_mapper):
     workdir = tmpdir / "analysis"
-    init(workdir, Path("testdata/reads.1.fastq.gz"))
+    init(workdir, TESTDATA_READS)
     copy_config(
         "tests/test_config.yaml",
         workdir / "blr.yaml",
         genome_reference=str(Path("testdata/chr1mini.fasta").absolute()),
+        read_mapper=read_mapper,
     )
     run(workdir=workdir, targets=["mapped.sorted.bam"])
+    n_input_fastq_reads = 2 * count_fastq_reads(workdir / "trimmed_barcoded.1.fastq.gz")
+    assert n_input_fastq_reads <= count_bam_alignments(workdir / "mapped.sorted.bam")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from blr.cli.init import init
+
+
+def test_init(tmpdir):
+    init(tmpdir / "analysis", Path("testdata/reads.1.fastq.gz"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,30 @@
 from pathlib import Path
 
 from blr.cli.init import init
+from blr.cli.run import run
+
+
+def copy_config(source, target, genome_reference=None):
+    """Copy config, possibly changing the genome_reference"""
+
+    with open(source) as infile:
+        with open(target, "w") as outfile:
+            for line in infile:
+                if genome_reference is not None and line.startswith("genome_reference:"):
+                    line = "genome_reference: " + str(Path("testdata/chr1mini.fasta").absolute())
+                outfile.write(line)
 
 
 def test_init(tmpdir):
     init(tmpdir / "analysis", Path("testdata/reads.1.fastq.gz"))
+
+
+def test_run(tmpdir):
+    workdir = tmpdir / "analysis"
+    init(workdir, Path("testdata/reads.1.fastq.gz"))
+    copy_config(
+        "tests/test_config.yaml",
+        workdir / "blr.yaml",
+        genome_reference=str(Path("testdata/chr1mini.fasta").absolute()),
+    )
+    run(workdir=workdir, targets=["mapped.sorted.bam"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pysam
 import pytest
-from xopen import xopen
+import dnaio
 
 from blr.cli.init import init
 from blr.cli.run import run
@@ -18,11 +18,11 @@ def count_bam_alignments(path):
 
 
 def count_fastq_reads(path):
-    with xopen(path) as f:
+    with dnaio.open(path) as f:
         n = 0
         for _ in f:
             n += 1
-    return n // 4
+    return n
 
 
 def copy_config(source, target, genome_reference=None, read_mapper=None):
@@ -54,5 +54,5 @@ def test_mappers(tmpdir, read_mapper):
         read_mapper=read_mapper,
     )
     run(workdir=workdir, targets=["mapped.sorted.bam"])
-    n_input_fastq_reads = 2 * count_fastq_reads(workdir / "trimmed_barcoded.1.fastq.gz")
+    n_input_fastq_reads = 2 * count_fastq_reads(Path(workdir / "trimmed_barcoded.1.fastq.gz"))
     assert n_input_fastq_reads <= count_bam_alignments(workdir / "mapped.sorted.bam")


### PR DESCRIPTION
The `tests/run.sh` script is becoming a bit crowded and hard to read because more and more tests are getting added to it. We should start using a proper test framework. This PR adds a couple of pytest tests that test the pipeline from Python. The idea would be to migrate all tests from the bash script eventually.

You’ll need to `conda install pytest` manually to run the tests locally.