### PR TITLE
Remove the picard_command configuration setting

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -120,7 +120,7 @@ rule mark_duplicates:
         metrics = "picard_mkdup_metrics.log",
         stderr = "picard_mkdup.log"
     shell:
-        "{config[picard_command]} -Xms{config[heap_space]}g MarkDuplicates"
+        "picard -Xms{config[heap_space]}g MarkDuplicates"
         " I={input.bam}"
         " O={output.bam}"
         " M={log.metrics}"
@@ -190,7 +190,7 @@ rule bam_to_fastq:
         bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam"
     log: "picard_samtofastq.log"
     shell:
-        "{config[picard_command]} -Xms{config[heap_space]}g SamToFastq"
+        "picard -Xms{config[heap_space]}g SamToFastq"
         " I={input.bam}"
         " FASTQ={output.r1_fastq}"
         " SECOND_END_FASTQ={output.r2_fastq} 2>> {log}"

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -4,7 +4,6 @@ molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 genome_reference:  # Path to indexed reference
-picard_command: picard #Picard run command.
 read_mapper: bowtie2  # Choose bwa or bowtie2
 
 #################

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -28,10 +28,6 @@ properties:
   genome_reference:
     type: [ "string", "null" ]
     description: Reference index prefix
-  picard_command:
-    type: string
-    description: Picard command to be used.
-    default: picard
   h1:
     type: string
     description: h1 adaptor sequnce, appears before barcode in read1


### PR DESCRIPTION
We instead rely on $PATH for finding the binary.

See #122