### PR TITLE
Implement alternative duplicate markers

### DIFF
--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -28,7 +28,7 @@ dependencies:
   - giflib=5.1.7=h516909a_1
   - gitdb2=2.0.6=py_0
   - gitpython=3.0.4=py_0
-  - htslib=1.9=ha228f0b_7
+  - htslib=1.9=h244ad75_9
   - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
   - importlib_metadata=0.23=py36_0
@@ -40,7 +40,7 @@ dependencies:
   - libblas=3.8.0=14_openblas
   - libcblas=3.8.0=14_openblas
   - libcurl=7.65.3=hda55be3_0
-  - libdeflate=1.0=h14c3975_1
+  - libdeflate=1.3=h516909a_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
@@ -72,13 +72,15 @@ dependencies:
   - pycparser=2.19=py36_1
   - pyopenssl=19.0.0=py36_0
   - pyrsistent=0.15.4=py36h516909a_0
-  - pysam=0.15.3=py36hda2845c_1
+  - pysam=0.15.3=py36hbcae180_3
   - pysocks=1.7.1=py36_0
   - python=3.6.7=h357f687_1005
   - pyyaml=5.1.2=py36h516909a_0
   - ratelimiter=1.2.0=py36_1000
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py36_1
+  - sambamba=0.6.6=2
+  - samblaster=0.1.24=hc9558a2_3
   - samtools=1.9=h10a08f8_12
   - setuptools=41.4.0=py36_0
   - six=1.12.0=py36_1000

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -63,6 +63,8 @@ dependencies:
   - ratelimiter=1.2.0=py36_1000
   - readline=8.0=hcfe32e1_0
   - requests=2.22.0=py36_1
+  - sambamba=0.6.6=2
+  - samblaster=0.1.24=h770b8ee_3
   - samtools=1.9=h8aa4d43_12
   - setuptools=41.4.0=py36_0
   - six=1.12.0=py36_1000

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ channels:
   - conda-forge
   - bioconda
   - defaults
-  - BioBuilds
 dependencies:
   - nomkl
   - python=3.6

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - conda-forge
   - bioconda
   - defaults
+  - BioBuilds
 dependencies:
   - nomkl
   - python=3.6
@@ -14,6 +15,8 @@ dependencies:
   - pysam
   - picard=2.10
   - cutadapt=2.5
+  - sambamba=0.6.6
+  - samblaster
   - samtools
   - snakemake-minimal
   - starcode

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -95,21 +95,17 @@ rule map_reads:
                 " {input.r2_fastq}",
         }
         command = commands[config["read_mapper"]].format(**locals(), **globals())
-        if config["duplicate_marker"] == "samblaster":
-            shell(
-                "{command} 2> >(tee {log} >&2) |"
-                "samblaster |"
-                "samtools sort -"
-                " -@ {threads}"
-                " -O BAM > {output.bam}"
-            )
-        else:
-            shell(
-                "{command} 2> >(tee {log} >&2) |"
-                "samtools sort -"
-                " -@ {threads}"
-                " -O BAM > {output.bam}"
-            )
+
+        # Add duplicate marking to map_reads pipe if samblaster selected.
+        mkdup = "samblaster |" if config["duplicate_marker"] == "samblaster" else ""
+
+        shell(
+            "{command} 2> >(tee {log} >&2) |"
+            "{mkdup}"
+            "samtools sort -"
+            " -@ {threads}"
+            " -O BAM > {output.bam}"
+        )
 
 
 rule tagbam:
@@ -134,8 +130,8 @@ rule mark_duplicates:
     log: "mark_duplicates.log"
     threads: 20
     shell:
-        "sambamba markdup "
-        " -t {threads} "
+        "sambamba markdup"
+        " -t {threads}"
         " {input.bam}"
         " {output.bam} 2> {log}"
 

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -124,14 +124,35 @@ rule mark_duplicates:
     input:
         bam = "mapped.sorted.tag.bam"
     log:
-        metrics = "picard_mkdup_metrics.log",
-        stderr = "picard_mkdup.log"
-    shell:
-        "picard -Xms{config[heap_space]}g MarkDuplicates"
-        " I={input.bam}"
-        " O={output.bam}"
-        " M={log.metrics}"
-        " ASSUME_SORT_ORDER=coordinate 2> {log.stderr}"
+        metrics = "mark_duplicates_metrics.txt",
+        stderr = "mark_duplicates.log"
+    threads: 20
+    run:
+        commands = {
+            "sambamba":
+                "sambamba markdup "
+                " -t {threads} "
+                " {input.bam}"
+                " {output.bam} 2> {log.stderr}",
+            "samblaster":
+                "samtools sort"
+                " -n"
+                " -O SAM "
+                " -@ {threads}"
+                " {input.bam} |"
+                " samblaster 2> {log.stderr} |"
+                " samtools sort - "
+                "-@ {threads}"
+                " -O BAM > {output.bam}",
+            "picard":
+                "picard -Xms{config[heap_space]}g MarkDuplicates"
+                " I={input.bam}"
+                " O={output.bam}"
+                " M={log.metrics}"
+                " ASSUME_SORT_ORDER=coordinate 2> {log.stderr}"
+        }
+        command = commands[config["duplicate_marker"]].format(**locals(), **globals())
+        shell(command)
 
 
 rule clusterrmdup:

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -1,5 +1,4 @@
 from snakemake.utils import validate
-import os
 
 configfile: "blr.yaml"
 validate(config, "config.schema.yaml")
@@ -96,18 +95,27 @@ rule map_reads:
                 " {input.r2_fastq}",
         }
         command = commands[config["read_mapper"]].format(**locals(), **globals())
-        shell(
-            "{command} 2> >(tee {log} >&2) |"
-            "samtools sort -"
-            " -@ {threads}"
-            " -O BAM > {output.bam}"
-        )
+        if config["duplicate_marker"] == "samblaster":
+            shell(
+                "{command} 2> >(tee {log} >&2) |"
+                "samblaster |"
+                "samtools sort -"
+                " -@ {threads}"
+                " -O BAM > {output.bam}"
+            )
+        else:
+            shell(
+                "{command} 2> >(tee {log} >&2) |"
+                "samtools sort -"
+                " -@ {threads}"
+                " -O BAM > {output.bam}"
+            )
 
 
 rule tagbam:
     # Add barcodes to BAM
     output:
-        bam = "mapped.sorted.tag.bam"
+        bam = "mapped.sorted.tag.mkdup.bam" if config['duplicate_marker'] == 'samblaster' else "mapped.sorted.tag.bam"
     input:
         bam = "mapped.sorted.bam"
     log: "tag_bam.stderr"
@@ -123,36 +131,13 @@ rule mark_duplicates:
         bam = "mapped.sorted.tag.mkdup.bam"
     input:
         bam = "mapped.sorted.tag.bam"
-    log:
-        metrics = "mark_duplicates_metrics.txt",
-        stderr = "mark_duplicates.log"
+    log: "mark_duplicates.log"
     threads: 20
-    run:
-        commands = {
-            "sambamba":
-                "sambamba markdup "
-                " -t {threads} "
-                " {input.bam}"
-                " {output.bam} 2> {log.stderr}",
-            "samblaster":
-                "samtools sort"
-                " -n"
-                " -O SAM "
-                " -@ {threads}"
-                " {input.bam} |"
-                " samblaster 2> {log.stderr} |"
-                " samtools sort - "
-                "-@ {threads}"
-                " -O BAM > {output.bam}",
-            "picard":
-                "picard -Xms{config[heap_space]}g MarkDuplicates"
-                " I={input.bam}"
-                " O={output.bam}"
-                " M={log.metrics}"
-                " ASSUME_SORT_ORDER=coordinate 2> {log.stderr}"
-        }
-        command = commands[config["duplicate_marker"]].format(**locals(), **globals())
-        shell(command)
+    shell:
+        "sambamba markdup "
+        " -t {threads} "
+        " {input.bam}"
+        " {output.bam} 2> {log}"
 
 
 rule clusterrmdup:

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -5,6 +5,7 @@ num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 genome_reference:  # Path to indexed reference
 read_mapper: bowtie2  # Choose bwa, bowtie2 or minimap2
+duplicate_marker: sambamba # Choose sambamba or samblaster or picard
 
 #################
 # Trim settings #

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -4,7 +4,7 @@ molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 genome_reference:  # Path to indexed reference
-read_mapper: bowtie2  # Choose bwa or bowtie2 or minimap2
+read_mapper: bowtie2  # Choose bwa, bowtie2 or minimap2
 duplicate_marker: sambamba # Choose sambamba or samblaster
 
 #################

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -4,8 +4,8 @@ molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
 genome_reference:  # Path to indexed reference
-read_mapper: bowtie2  # Choose bwa, bowtie2 or minimap2
-duplicate_marker: sambamba # Choose sambamba or samblaster or picard
+read_mapper: bowtie2  # Choose bwa or bowtie2 or minimap2
+duplicate_marker: sambamba # Choose sambamba or samblaster
 
 #################
 # Trim settings #

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -27,7 +27,7 @@ properties:
     description: Which read mapper to use
   duplicate_marker:
     type: string
-    pattern: "sambamba|samblaster|picard"
+    pattern: "sambamba|samblaster"
     description: Which duplicate marking tools to use
   genome_reference:
     type: [ "string", "null" ]

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -25,6 +25,10 @@ properties:
     type: string
     pattern: "bwa|bowtie2|minimap2"
     description: Which read mapper to use
+  duplicate_marker:
+    type: string
+    pattern: "sambamba|samblaster|picard"
+    description: Which duplicate marking tools to use
   genome_reference:
     type: [ "string", "null" ]
     description: Reference index prefix

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,6 +9,8 @@ cutadapt --version
 starcode --version
 snakemake --version
 blr --version
+samblaster --version
+sambamba --version
 
 ( cd testdata && bwa index chr1mini.fasta )
 ( cd testdata && bowtie2-build chr1mini.fasta chr1mini.fasta > /dev/null )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -23,7 +23,7 @@ cp tests/test_config.yaml outdir-bowtie2/blr.yaml
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == bfe1f589782a502a6b123e5edcbe9b3e
+test $m == e389e3f6e8ba14466f232b19fa1a0ee5
 
 # Test phasing
 blr run phasing_stats.txt

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,7 +6,7 @@ sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' 
 picard_command: picard
 read_mapper: bowtie2
 genome_reference: ../testdata/chr1mini.fasta
-duplicate_marker: sambamba # Choose sambamba or samblaster or picard
+duplicate_marker: sambamba # Choose sambamba or samblaster
 
 #################
 # Trim settings #

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -6,6 +6,7 @@ sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' 
 picard_command: picard
 read_mapper: bowtie2
 genome_reference: ../testdata/chr1mini.fasta
+duplicate_marker: sambamba # Choose sambamba or samblaster or picard
 
 #################
 # Trim settings #

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -3,7 +3,6 @@ cluster_tag: BX    # Used to store barcode cluster id in bam file. 'BX' is 10x g
 molecule_tag: MI  # Used to store molecule ID, same as 10x default.
 num_mol_tag: MN # Used to store number of molecules per barcode
 sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' is 10x genomic default
-picard_command: picard
 read_mapper: bowtie2
 genome_reference: ../testdata/chr1mini.fasta
 duplicate_marker: sambamba # Choose sambamba or samblaster


### PR DESCRIPTION
Here is the implementation of sambamba and samblaster as duplicate markers. Picard MarkDuplicates has been removed as it was proven to be quite resource intensive and slow (see #113).

Note that samblaster is integrated as pipe in the mapping step as this is the intended benefit of the tool. Thus it will skip the `mark_duplicates` step and instead go from `tagbam` directly to `clusterrmdup`. The naming is a bit off as the file `mapped.sorted.bam` now has duplicates marked. I think this is fine for now and we can change it whenever we select a specific tool for marking duplicates. But comment if you have any objections or suggestions!