### PR TITLE
Changes to help facilitate streaming

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -157,7 +157,6 @@ rule filterclusters:
     shell:
         "blr filterclusters"
         " {input.bam}"
-        " -O BAM"
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -95,7 +95,7 @@ rule tagbam:
     shell:
         "blr tagbam"
         " {input.bam}"
-        " {output.bam}"
+        " -o {output.bam}"
         " -b {config[cluster_tag]} 2> {log}"
 
 
@@ -124,8 +124,8 @@ rule clusterrmdup:
     shell:
         "blr clusterrmdup"
         " {input.bam}"
-        " {output.bam}"
         " {output.merges}"
+        " -o {output.bam}"
         " -b {config[cluster_tag]} 2>> {log}"
 
 
@@ -139,7 +139,7 @@ rule buildmolecules:
     shell:
         "blr buildmolecules"
         " {input.bam}"
-        " {output.bam}"
+        " -o {output.bam}"
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"
@@ -157,7 +157,7 @@ rule filterclusters:
     shell:
         "blr filterclusters"
         " {input.bam}"
-        " -"
+        " -O BAM"
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     summary = Summary()
-    out_mode = utils.get_output_mode(args.output, args.output_format)
 
     # Build molecules from BCs and reads
     with pysam.AlignmentFile(args.input, "rb") as infile:
@@ -28,7 +27,7 @@ def main(args):
 
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, out_mode, template=openin) as openout:
+            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name
@@ -276,10 +275,7 @@ def add_arguments(parser):
                              "-b/--barcode-tag.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
-                             "filename unless -O/--output-format is specified.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
-                        help="Specify output format.")
+                        help="Write output BAM to file rather then stdout.")
     parser.add_argument("-t", "--threshold", type=int, default=4,
                         help="Threshold for how many reads are required for including given molecule in statistics "
                              "(except_reads_per_molecule). Default: %(default)s")

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -1,5 +1,5 @@
 """
-Tags .bam file with molecule information based on barcode sequence and genomic proximity.
+Tags SAM/BAM file with molecule information based on barcode sequence and genomic proximity.
 
 A molecule is defined by having 1) minimum --threshold reads and including all reads with the same barcode which are 2)
 a maximum distance of --window between any given reads.
@@ -17,17 +17,18 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     summary = Summary()
+    out_mode = utils.get_output_mode(args.output, args.output_format)
 
     # Build molecules from BCs and reads
-    with pysam.AlignmentFile(args.bam, "rb") as infile:
+    with pysam.AlignmentFile(args.input, "rb") as infile:
         bc_to_mol_dict, header_to_mol_dict = build_molecules(pysam_openfile=infile,
                                                              barcode_tag=args.barcode_tag,
                                                              window=args.window, min_reads=args.threshold,
                                                              summary=summary)
 
     # Writes filtered out
-    with pysam.AlignmentFile(args.bam, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
+    with pysam.AlignmentFile(args.input, "rb") as openin, \
+            pysam.AlignmentFile(args.output, out_mode, template=openin) as openout:
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name
@@ -270,12 +271,17 @@ class Summary:
 
 
 def add_arguments(parser):
-    parser.add_argument("bam",
-                        help="Sorted BAM file tagged with barcode in the same tag as specified in -b/--barcode-tag.")
-    parser.add_argument("output",
-                        help="Output BAM file with molecule tags found under the tag specified at -m/--molecule-tag "
-                             "and molecules number for each barcode under the specified -n/--number-tag.")
+    parser.add_argument("input",
+                        help="Sorted SAM/BAM file tagged with barcode in the same tag as specified in "
+                             "-b/--barcode-tag.")
 
+    parser.add_argument("-o", "--output", default="-",
+                        help="Output SAM/BAM file with molecule tags found under the tag specified at "
+                             "-m/--molecule-tag and molecules number for each barcode under the specified "
+                             "-n/--number-tag. Default: write to stdout.")
+    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"], default="SAM",
+                        help="Specify output format. If a output file name is specified the format is inferred "
+                             "therefrom. Default: %(default)s")
     parser.add_argument("-t", "--threshold", type=int, default=4,
                         help="Threshold for how many reads are required for including given molecule in statistics "
                              "(except_reads_per_molecule). Default: %(default)s")

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -276,12 +276,10 @@ def add_arguments(parser):
                              "-b/--barcode-tag.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Output SAM/BAM file with molecule tags found under the tag specified at "
-                             "-m/--molecule-tag and molecules number for each barcode under the specified "
-                             "-n/--number-tag. Default: write to stdout.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"], default="SAM",
-                        help="Specify output format. If a output file name is specified the format is inferred "
-                             "therefrom. Default: %(default)s")
+                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
+                             "filename unless -O/--output-format is specified.")
+    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
+                        help="Specify output format.")
     parser.add_argument("-t", "--threshold", type=int, default=4,
                         help="Threshold for how many reads are required for including given molecule in statistics "
                              "(except_reads_per_molecule). Default: %(default)s")

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     logger.info("Starting Analysis")
-    out_mode = utils.get_output_mode(args.output, args.output_format)
     summary = Summary()
 
     current_cache_rp = dict()
@@ -104,7 +103,7 @@ def main(args):
     bc_seq_already_written = set()
     with open(args.merge_log, "w") as bc_merge_file, \
             pysam.AlignmentFile(args.input, "rb") as infile, \
-            pysam.AlignmentFile(args.output, out_mode, template=infile) as out:
+            pysam.AlignmentFile(args.output, "wb", template=infile) as out:
         for read in tqdm(infile.fetch(until_eof=True), desc="Writing output", total=summary.tot_reads):
 
             # If read barcode in merge dict, change tag and header to compensate.
@@ -299,10 +298,7 @@ def add_arguments(parser):
                              "{old barcode id},{new barcode id}")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
-                             "filename unless -O/--output-format is specified.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
-                        help="Specify output format.")
+                        help="Write output BAM to file rather then stdout.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-w", "--window", type=int, default=100000,

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -299,10 +299,10 @@ def add_arguments(parser):
                              "{old barcode id},{new barcode id}")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Sorted SAM/BAM file without barcode duplicates. Default: write to stdout.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"], default="SAM",
-                        help="Specify output format. If a output file name is specified the format is inferred "
-                             "therefrom. Default: %(default)s")
+                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
+                             "filename unless -O/--output-format is specified.")
+    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
+                        help="Specify output format.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-w", "--window", type=int, default=100000,

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -94,10 +94,10 @@ def add_arguments(parser):
                              "To read from stdin use '-'.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Output filtered SAM/BAM file. Default: write to stdout.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"], default="SAM",
-                        help="Specify output format. If a output file name is specified the format is inferred "
-                             "therefrom. Default: %(default)s")
+                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
+                             "filename unless -O/--output-format is specified.")
+    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
+                        help="Specify output format.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-M", "--max_molecules", type=int, default=500,

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -15,14 +15,12 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     tags_to_remove = [args.barcode_tag, args.molecule_tag, args.number_tag]
-    out_mode = utils.get_output_mode(args.output, args.output_format)
     summary = Summary(tags_to_remove)
     logger.info("Starting")
 
-    logger.info(f"Writing filtered {args.output_format} file")
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, out_mode, template=openin) as openout:
+            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
         for read in tqdm(openin.fetch(until_eof=True)):
             summary.tot_reads += 1
             no_mols = utils.get_bamtag(pysam_read=read, tag=args.number_tag)
@@ -94,10 +92,7 @@ def add_arguments(parser):
                              "To read from stdin use '-'.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
-                             "filename unless -O/--output-format is specified.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
-                        help="Specify output format.")
+                        help="Write output BAM to file rather then stdout.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-M", "--max_molecules", type=int, default=500,

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -53,11 +53,10 @@ def add_arguments(parser):
                              "from stdin use '-'.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="SAM/BAM file with barcodes information in the specified SAM tags. Default: write to "
-                             "stdout.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"], default="SAM",
-                        help="Specify output format. If a output file name is specified the format is inferred "
-                             "therefrom. Default: %(default)s")
+                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
+                             "filename unless -O/--output-format is specified.")
+    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
+                        help="Specify output format.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-s", "--sequence-tag", default="RX",

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -5,7 +5,6 @@ Transfers barcode sequence information from the input file alignment name to SAM
 import pysam
 import logging
 from tqdm import tqdm
-from blr import utils
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +13,11 @@ def main(args):
 
     # Generate dict with bc => bc_cluster consensus sequence
     logger.info("Starting analysis")
-    out_mode = utils.get_output_mode(args.output, args.output_format)
     alignments_missing_bc = 0
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
     with pysam.AlignmentFile(args.input, "rb") as infile, \
-            pysam.AlignmentFile(args.output, out_mode, template=infile) as out:
+            pysam.AlignmentFile(args.output, "wb", template=infile) as out:
 
         for read in tqdm(infile.fetch(until_eof=True), desc="Reading input"):
             try:
@@ -53,10 +51,7 @@ def add_arguments(parser):
                              "from stdin use '-'.")
 
     parser.add_argument("-o", "--output", default="-",
-                        help="Write output SAM/BAM to file rather then stdout. Format is inferred from the "
-                             "filename unless -O/--output-format is specified.")
-    parser.add_argument("-O", "--output-format", choices=["SAM", "BAM"],
-                        help="Specify output format.")
+                        help="Write output BAM to file rather then stdout.")
     parser.add_argument("-b", "--barcode-tag", default="BX",
                         help="SAM tag for storing the error corrected barcode. Default: %(default)s")
     parser.add_argument("-s", "--sequence-tag", default="RX",

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -52,24 +52,3 @@ def get_bamtag(pysam_read, tag):
         return pysam_read.get_tag(tag)
     except KeyError:
         return None
-
-
-def get_output_mode(filename, spec_format):
-    """
-    Get the pySAM mode specification string. Frist from the spec_format and second from the output filename. If
-    neither is specified the DEFAULT_MODE is returned which is SAM ('w').
-    :param filename: String that is used to infer format.
-    :param spec_format: Should be either SAM or BAM.
-    :return: String containing the pySAM mode information. String is 'w' for SAM and 'wb' for BAM.
-    """
-    format_to_mode = {
-        "SAM": "w",
-        "BAM": "wb"
-    }
-
-    DEFAULT_MODE = "w"
-
-    if filename != "-" and not spec_format:
-        spec_format = filename.split(".")[-1].upper()
-
-    return format_to_mode.pop(spec_format, DEFAULT_MODE)

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -56,9 +56,9 @@ def get_bamtag(pysam_read, tag):
 
 def get_output_mode(filename, spec_format):
     """
-    Get the pySAM mode specification string for the specified output filename and format.
-    :param filename: String that is used to infer format. In case of writing to stdout, i.e. when '-' is speficied,
-    then the spec_format is used.
+    Get the pySAM mode specification string. Frist from the spec_format and second from the output filename. If
+    neither is specified the DEFAULT_MODE is returned which is SAM ('w').
+    :param filename: String that is used to infer format.
     :param spec_format: Should be either SAM or BAM.
     :return: String containing the pySAM mode information. String is 'w' for SAM and 'wb' for BAM.
     """
@@ -67,6 +67,9 @@ def get_output_mode(filename, spec_format):
         "BAM": "wb"
     }
 
-    if filename != "-":
+    DEFAULT_MODE = "w"
+
+    if filename != "-" and not spec_format:
         spec_format = filename.split(".")[-1].upper()
-    return format_to_mode[spec_format]
+
+    return format_to_mode.pop(spec_format, DEFAULT_MODE)

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -52,3 +52,21 @@ def get_bamtag(pysam_read, tag):
         return pysam_read.get_tag(tag)
     except KeyError:
         return None
+
+
+def get_output_mode(filename, spec_format):
+    """
+    Get the pySAM mode specification string for the specified output filename and format.
+    :param filename: String that is used to infer format. In case of writing to stdout, i.e. when '-' is speficied,
+    then the spec_format is used.
+    :param spec_format: Should be either SAM or BAM.
+    :return: String containing the pySAM mode information. String is 'w' for SAM and 'wb' for BAM.
+    """
+    format_to_mode = {
+        "SAM": "w",
+        "BAM": "wb"
+    }
+
+    if filename != "-":
+        spec_format = filename.split(".")[-1].upper()
+    return format_to_mode[spec_format]


### PR DESCRIPTION
Related to issue #116 

 - Enable writing to stdout in SAM or BAM format for `tagbam`, `clusterrmdup`, `buildmolecules` and `filterclusters`.
 - Updated information in docstrings and help messages. Included info on which scripts can handle reading from stdin (currently `tagbam` and `filterclusters`.)