### PR TITLE
Pytest update

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,8 @@ from blr.cli.init import init
 from blr.cli.run import run
 
 TESTDATA_READS = Path("testdata/reads.1.fastq.gz")
-
+TEST_CONFIG = Path("tests/test_config.yaml")
+REFERENCE_GENOME = "testdata/chr1mini.fasta"
 
 def count_bam_alignments(path):
     with pysam.AlignmentFile(path) as af:
@@ -50,9 +51,9 @@ def test_mappers(tmpdir, read_mapper):
     workdir = tmpdir / "analysis"
     init(workdir, TESTDATA_READS)
     copy_config(
-        "tests/test_config.yaml",
+        TEST_CONFIG,
         workdir / "blr.yaml",
-        genome_reference=str(Path("testdata/chr1mini.fasta").absolute()),
+        genome_reference=REFERENCE_GENOME,
         read_mapper=read_mapper,
     )
     run(workdir=workdir, targets=["mapped.sorted.bam"])
@@ -65,9 +66,9 @@ def test_duplicate_markers(tmpdir, duplicate_marker):
     workdir = tmpdir / "analysis"
     init(workdir, TESTDATA_READS)
     copy_config(
-        "tests/test_config.yaml",
+        TEST_CONFIG,
         workdir / "blr.yaml",
-        genome_reference=str(Path("testdata/chr1mini.fasta").absolute()),
+        genome_reference=REFERENCE_GENOME,
         read_mapper="bwa",
         duplicate_marker=duplicate_marker
     )
@@ -80,9 +81,9 @@ def test_final_compressed_reads_exist(tmpdir):
     workdir = tmpdir / "analysis"
     init(workdir, TESTDATA_READS)
     copy_config(
-        "tests/test_config.yaml",
+        TEST_CONFIG,
         workdir / "blr.yaml",
-        genome_reference=str(Path("testdata/chr1mini.fasta").absolute()),
+        genome_reference=REFERENCE_GENOME,
         read_mapper="bwa"
     )
     targets = ("reads.1.final.fastq.gz", "reads.2.final.fastq.gz")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,6 @@ def test_duplicate_markers(tmpdir, duplicate_marker):
         TEST_CONFIG,
         workdir / "blr.yaml",
         genome_reference=REFERENCE_GENOME,
-        read_mapper="bwa",
         duplicate_marker=duplicate_marker
     )
     run(workdir=workdir, targets=["mapped.sorted.tag.mkdup.bam"])
@@ -84,7 +83,6 @@ def test_final_compressed_reads_exist(tmpdir):
         TEST_CONFIG,
         workdir / "blr.yaml",
         genome_reference=REFERENCE_GENOME,
-        read_mapper="bwa"
     )
     targets = ("reads.1.final.fastq.gz", "reads.2.final.fastq.gz")
     run(workdir=workdir, targets=targets)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ TESTDATA_READS = Path("testdata/reads.1.fastq.gz")
 TEST_CONFIG = Path("tests/test_config.yaml")
 REFERENCE_GENOME = Path("testdata/chr1mini.fasta").absolute()
 
+
 def count_bam_alignments(path):
     with pysam.AlignmentFile(path) as af:
         n = 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from blr.cli.run import run
 
 TESTDATA_READS = Path("testdata/reads.1.fastq.gz")
 TEST_CONFIG = Path("tests/test_config.yaml")
-REFERENCE_GENOME = "testdata/chr1mini.fasta"
+REFERENCE_GENOME = Path("testdata/chr1mini.fasta").absolute()
 
 def count_bam_alignments(path):
     with pysam.AlignmentFile(path) as af:
@@ -27,13 +27,13 @@ def count_fastq_reads(path):
 
 
 def copy_config(source, target, genome_reference=None, read_mapper=None, duplicate_marker=None):
-    """Copy config, possibly changing genome_reference or read_mapper"""
+    """Copy config, possibly changing any non-None arguments"""
 
     with open(source) as infile:
         with open(target, "w") as outfile:
             for line in infile:
                 if genome_reference is not None and line.startswith("genome_reference:"):
-                    path = Path("testdata/chr1mini.fasta").absolute()
+                    path = Path(genome_reference).absolute()
                     line = f"genome_reference: {path}\n"
                 if read_mapper is not None and line.startswith("read_mapper:"):
                     line = f"read_mapper: {read_mapper}\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,7 @@ def copy_config(source, target, genome_reference=None, read_mapper=None, duplica
         with open(target, "w") as outfile:
             for line in infile:
                 if genome_reference is not None and line.startswith("genome_reference:"):
-                    path = Path(genome_reference).absolute()
-                    line = f"genome_reference: {path}\n"
+                    line = f"genome_reference: {genome_reference}\n"
                 if read_mapper is not None and line.startswith("read_mapper:"):
                     line = f"read_mapper: {read_mapper}\n"
                 if duplicate_marker is not None and line.startswith("duplicate_marker:"):


### PR DESCRIPTION
I noticed some inconsistencies in the pytest file when I was about to add some other things so I thought I'd make some changes.

- I moved the test config file and the genome reference to the top to avoid having repetitive hard-coded strings for the same thing at multiple locations in the script.
- The `copy_config` documentation was updated.
- The `copy_config` didn't use the corresponding input argument for `genome_reference` to the function, now it does.
- I removed the `read_mapper` input from test which does not run several different ones.