### PR TITLE
Output stats file from `buildmolecules`

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -132,7 +132,8 @@ rule clusterrmdup:
 rule buildmolecules:
     # Groups reads into molecules depending on their genomic position and barcode
     output:
-        bam = "mapped.sorted.tag.mkdup.bcmerge.mol.bam"
+        bam = "mapped.sorted.tag.mkdup.bcmerge.mol.bam",
+        stats = expand("{stat}.tsv", stat=['molecules_per_bc', 'molecule_stats'])
     input:
         bam = "mapped.sorted.tag.mkdup.bcmerge.bam"
     log: "buildmolecules.log"
@@ -140,6 +141,7 @@ rule buildmolecules:
         "blr buildmolecules"
         " {input.bam}"
         " -o {output.bam}"
+        " --stats-files"
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"


### PR DESCRIPTION
Now the pipeline output the stats files.

I also made some additional changes to `buildmolecules`:
- Stats files are now TSV files.
- Added column headers to the files.
- Included barcode in `molecules_per_bc.tsv`.
- `write_molecule_stats` is now a function as it was not related to the `Summary` class. 
