### PR TITLE
Removed pipes due to sporadic errors

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -14,13 +14,6 @@ rule final:
     input: "reads.1.final.fastq.gz", "reads.2.final.fastq.gz"
 
 
-rule compress:
-    output: "{sample}.fastq.gz"
-    input: "{sample}.fastq"
-    shell:
-        "pigz < {input} > {output}"
-
-
 rule starcode_clustering:
     # Cluster DBS barcodes using starcode
     output:
@@ -169,8 +162,8 @@ rule filterclusters:
 rule bam_to_fastq:
     # Convert final BAM file to FASTQ files for read 1 and 2
     output:
-        r1_fastq = pipe("reads.1.final.fastq"),
-        r2_fastq = pipe("reads.2.final.fastq")
+        r1_fastq = "reads.1.final.fastq.gz",
+        r2_fastq = "reads.2.final.fastq.gz"
     input:
         bam = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam"
     log: "picard_samtofastq.log"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,5 @@ def test_final_compressed_reads_exist(tmpdir):
     )
     targets = ("reads.1.final.fastq.gz", "reads.2.final.fastq.gz")
     run(workdir=workdir, targets=targets)
-    import time
-    time.sleep(2)
     for filename in targets:
         assert Path(workdir / filename).exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,5 +87,7 @@ def test_final_compressed_reads_exist(tmpdir):
     )
     targets = ("reads.1.final.fastq.gz", "reads.2.final.fastq.gz")
     run(workdir=workdir, targets=targets)
+    import time
+    time.sleep(2)
     for filename in targets:
         assert Path(workdir / filename).exists()


### PR DESCRIPTION
After merging #147 we got sporadic errors where the named pipe could not be found, example:

```
/bin/bash: reads.1.final.fastq: No such file or directory
```

We reverted to making picard SamToFastq write gzipped file directly for now. 