### PR TITLE
Add common summary tool

### DIFF
--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+import sys
 
 
 def is_1_2(s, t):
@@ -52,3 +53,27 @@ def get_bamtag(pysam_read, tag):
         return pysam_read.get_tag(tag)
     except KeyError:
         return None
+
+
+def print_stats(summary, name=None, value_width=15, print_to=sys.stderr):
+    """
+    Prints stats in nice table with two column for the key and value pairs in summary
+    :param summary: collections.Coutner object
+    :param name: name of script for header e.g. '__name__'
+    :param value_width: width for values column in table
+    :param print_to: Where to direct output
+    """
+    # Get widths for formatting
+    max_name_width = max(map(len, summary.keys()))
+    width = value_width + max_name_width + 1
+
+    # Header
+    print("="*width, file=print_to)
+    print(f"STATS SUMMARY - {name}", file=print_to)
+    print("-"*width, file=print_to)
+
+    # Print stats in columns
+    for name, value in summary.items():
+        print(f"{name:<{max_name_width}} {value:>{value_width},}", file=print_to)
+
+    print("="*width, file=print_to)


### PR DESCRIPTION
Related to #79.

I removed the different `Summary` classes used in the scripts `buildmolecules`, `filterclusters`and `clusterrmdup` and instead used `collecitons.Counter` to store these stats in a dictionary. This makes it easy to add new statistics to the summary as you define them on the spot rather then in the `init` function of the `Summary` class. 

**Examples**
To add a new counter just do something like:

```
for thing in things:
   if thing.is_nice():
      summary["My counts"] += 1
```
You can also add values that you want in the summary directly e.g

```
my_list = [0, 2, 51, 64, 621, 2, 51]
summary["My sum"] = sum(my_list)
```

I added a common `print_stats` function in `utils` that can produce nicely formatted statistics from a dictionary-like object such as the `Counter`. It will produce output like this:

```
===========================================
STATS SUMMARY - blr.cli.my_tool
-------------------------------------------
My counts                            2,316
My sum                                 725
===========================================
```
