### PR TITLE
Move arguments to config file

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -27,7 +27,7 @@ rule starcode_clustering:
         " starcode"
         " -o {output}"
         " -t {threads}"
-        " -d 2"
+        " -d {config[barcode_max_dist]}"
         " --print-clusters"
         " 2> {log}"
 
@@ -155,7 +155,7 @@ rule filterclusters:
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"
-        " -M 260"
+        " -M {config[max_molecules_per_bc]}"
         " 2>> {log} |"
         " tee {output.bam} |"
         " samtools index  - {output.bai}"

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -6,6 +6,8 @@ sequence_tag: RX    # Used to store original barcode sequence in bam file. 'RX' 
 genome_reference:  # Path to indexed reference
 read_mapper: bowtie2  # Choose bwa, bowtie2 or minimap2
 duplicate_marker: sambamba # Choose sambamba or samblaster
+barcode_max_dist: 2 # Max edit distance (Leveshtein distance) allowed to cluster two barcode sequences together
+max_molecules_per_bc: 260 # Max number of molecules allowed for a single barcode (removes if bc has > 260 molecules).
 
 #################
 # Trim settings #

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -50,3 +50,10 @@ properties:
   phasing_ground_truth:
     type: [ "string", "null" ]
     description: Path to phased variants used to compute phasing stats.
+  barcode_max_dist:
+    type: integer
+    description: Max edit distance (Leveshtein distance) allowed to cluster two barcode sequences together
+  max_molecules_per_bc:
+    type: integer
+    description: Max number of molecules allowed for a single barcode (removes if bc has > 260 molecules).
+


### PR DESCRIPTION
Moved `starcode`'s cluster distance and `blr filterclusters`'s max barcode number to config since it can be useful to change this depending on the dataset. 