### PR TITLE
Update tagbam

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -89,7 +89,7 @@ rule tagbam:
         "blr tagbam"
         " {input.bam}"
         " -o {output.bam}"
-        " -b {config[cluster_tag]} 2> {log}"
+        " -t {config[cluster_tag]} {config[sequence_tag]} 2> {log}"
 
 
 rule mark_duplicates:

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -173,6 +173,7 @@ rule bam_to_fastq:
     shell:
         "samtools fastq"
         " -@ {threads}"
+        " -T {config[cluster_tag]},{config[sequence_tag]}"
         " {input.bam}"
         " -1 {output.r1_fastq}"
         " -2 {output.r2_fastq} 2>> {log}"

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -45,7 +45,7 @@ def main(args):
                         read.set_tag(tag, match.group("value"), value_type=match.group("type"))
                     summary[f"Reads with tag {tag}"] += 1
                 else:
-                    summary[f"reads without tag {tag}"] += 1
+                    summary[f"Reads without tag {tag}"] += 1
 
             out.write(read)
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -43,7 +43,7 @@ def main(args):
                     read.query_name = read.query_name.replace(divider + full_tag_string, "")
                     if not args.only_remove:
                         read.set_tag(tag, match.group("value"), value_type=match.group("type"))
-                    summary[f"reads with tag {tag}"] += 1
+                    summary[f"Reads with tag {tag}"] += 1
                 else:
                     summary[f"reads without tag {tag}"] += 1
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -1,5 +1,6 @@
 """
-Transfers tags from query headers to SAM tags. Currently tags in header must follow SAM tag format, e.g. BC:Z:<SEQUENCE>.
+Transfers SAM tags from query headers to SAM tags. Currently tags in header must follow SAM tag format, e.g.
+BC:Z:<SEQUENCE>.
 """
 
 import pysam

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -49,7 +49,7 @@ def main(args):
 
             out.write(read)
 
-    print_stats(summary, name="stats")
+    print_stats(summary, name=__name__)
     logger.info("Finished")
 
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -12,12 +12,11 @@ from blr.utils import print_stats
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_BAM_TAG_TYPES = "ABfHiZ" # From SAM format specs https://samtools.github.io/hts-specs/SAMtags.pdf
+ALLOWED_BAM_TAG_TYPES = "ABfHiZ"  # From SAM format specs https://samtools.github.io/hts-specs/SAMtags.pdf
 
 
 def main(args):
     logger.info("Starting analysis")
-    alignments_missing_bc = 0
     summary = Counter()
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
@@ -32,7 +31,7 @@ def main(args):
                 # If tag string is found, remove from header and set SAM tag value
                 if match:
                     full_tag_string = match.group(0)
-                    divider = read.query_name[match.start()-1]
+                    divider = read.query_name[match.start() - 1]
                     read.query_name = read.query_name.replace(divider + full_tag_string, "")
                     read.set_tag(match.group("tag"), match.group("value"), value_type=match.group("type"))
                     summary[f"reads with tag {tag}"] += 1
@@ -62,15 +61,22 @@ def find_tag(header, bam_tag, allowed_value_chars="ATGCN"):
     regex_tag_value = add_regex_name(pattern=pattern_tag_value, name="value")
 
     # regex pattern search for tag:type:value
-    regex_string = r":".join([regex_bam_tag,regex_allowed_types,regex_tag_value])
+    regex_string = r":".join([regex_bam_tag, regex_allowed_types, regex_tag_value])
     return re.search(regex_string, header)
 
 
 def add_regex_name(pattern, name):
+    """
+    Formats a string to fit the regex pattern for getting named match objects
+    :param pattern: str, regex pattern
+    :param name: str
+    :return: named regex string
+    """
     prefix = "(?P<"
     infix = ">"
     suffix = ")"
     return prefix + name + infix + pattern + suffix
+
 
 def add_arguments(parser):
     parser.add_argument("input",


### PR DESCRIPTION
To accommodate mappers like `ema` we need to have some more flexibility to `tagbam` since it requires, and outputs different output format of headers.

I rewrote `tagbam` to so it searches for regex patterns in query headers for any number of specified SAM tags. More importantly it is written to be compatible with adding new regex functions to search for other patterns. 

To add a new patten you you need to:
- write regex function (equivalent to build_regex_sam_tag())
- add format to options in argparser
- link format & regex function in REGEX_FUNCTION_DICT

**In the future** we could also some more modes for different mappers copying different information to tags.
- `--safe-mode` If tag already exists, check the header tag was identical (or cause error)
- `--soft-mode` Don't overwrite if tag already has a value.

**Bonus:** Since it is using regex rather than split() it now works regardless of what separator is used between the read name and barcode (currently `_`) and tags can be in any order.

**Lastly** I made `samtools fastq` include tags into the final fastq files.