### PR TITLE
clusterrmdup update

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,7 +27,7 @@ blr config \
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == e389e3f6e8ba14466f232b19fa1a0ee5
+test $m == de843a922d50db18d73617df1c9884b5
 
 # Test phasing
 blr run phasing_stats.txt


### PR DESCRIPTION
We had some issues with running `clusterrmdup` for large dataset (see #173 ) so I have done some updates to limit memory and increase performance. I also changed some aspects that would cause the script to miss some duplicates based on the [picard definition for duplicates](https://sourceforge.net/p/samtools/mailman/message/25062576/): 

"... find the 5' coordinates and mapping orientations of each read pair.  [...].  It then matches all read pairs that have identical 5' coordinates and orientations and marks as duplicates all but the "best" pair."

The previous script used the 5' and 3' positions of both reads and did not consider the orientation. Thus I have now changed so that only 5' positions and orientation is considered. The image below shows one such scenario were a duplicate between barcodes GTCCTTTGTTCCGTACTAAG and AATAGGTCTTTCGACATACG but the 3' end of read2 is trimmed differently. "test.master.bam" this previous script which miss this duplicate while the new script ("test.new.bam") detects it and merges the barcodes.    

![image](https://user-images.githubusercontent.com/27061883/70517194-7b5c8180-1b38-11ea-871a-8651d4d43992.png)



I have also had to implement a buffer system to be able to catch all read on a duplicate position. Consider the following scenario.
```
READ PAIR 1:    R1|--------->    <-------|R2
READ PAIR 2:    R1|--------->       <----|R2
Chromosome:  ==================================>
```

Buy the definition stated above the two read pairs (RP) are duplicates but R2 for RP2 is on a different position start position compared to R2 in RP1. Thus it will appear longer down in the coordinate sorted BAM file. The previous script looked at each position separately and would thus drop RP1 as possible duplicate. Now instead each RP within a defined window (currently 500 bp) is considered. Thus these cases can be caught and handled correctly.

**Other changes**
- Move `summary` away from global scope (see #167 )
- Factored out several functions.
- Name changes  

**Runtime for chr22 testdata.** 
Previous script
- real: 10m18.406s, 10m21.591s
- user: 10m16.232s, 10m19.550s
- sys: 0m1.316s, 0m1.035s

This script
- real: 8m3.786s, 8m6.691s
- user: 8m1.998s, 8m5.079s
- sys: 0m1.052s, 0m0.900s

