### PR TITLE
Update tagbam split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  #- if [ "$TRAVIS_OS_NAME" = "osx" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - source $HOME/miniconda/etc/profile.d/conda.sh
   - conda config --set always_yes yes --set changeps1 no

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum; fi
+  #- if [ "$TRAVIS_OS_NAME" = "osx" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - source $HOME/miniconda/etc/profile.d/conda.sh
   - conda config --set always_yes yes --set changeps1 no

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -111,7 +111,7 @@ rule tagbam:
         "blr tagbam"
         " {input.bam}"
         " -o {output.bam}"
-        " -b {config[cluster_tag]} 2> {log}"
+        " -t {config[cluster_tag]} {config[sequence_tag]} 2> {log}"
 
 
 rule mark_duplicates:

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -195,6 +195,7 @@ rule bam_to_fastq:
     shell:
         "samtools fastq"
         " -@ {threads}"
+        " -T {config[cluster_tag]},{config[sequence_tag]}"
         " {input.bam}"
         " -1 {output.r1_fastq}"
         " -2 {output.r2_fastq} 2>> {log}"

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -108,7 +108,7 @@ rule tagbam:
         bam = "mapped.sorted.bam"
     log: "tag_bam.log"
     run:
-        mode = "sam" if config["read_mapper"] is not "ema" else "ema"
+        mode = "sam" if config["read_mapper"] != "ema" else "ema"
         shell(
             "blr tagbam"
             " {input.bam}"

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -108,7 +108,7 @@ rule tagbam:
         bam = "mapped.sorted.bam"
     log: "tag_bam.log"
     run:
-        mode = "sam" if config["read_mapper"] != "ema" else "ema"
+        mode = "sam" if config["read_mapper"] is not "ema" else "ema"
         shell(
             "blr tagbam"
             " {input.bam}"

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -106,12 +106,15 @@ rule tagbam:
         bam = "mapped.sorted.tag.mkdup.bam" if config['duplicate_marker'] == 'samblaster' else "mapped.sorted.tag.bam"
     input:
         bam = "mapped.sorted.bam"
-    log: "tag_bam.stderr"
-    shell:
-        "blr tagbam"
-        " {input.bam}"
-        " -o {output.bam}"
-        " -t {config[cluster_tag]} {config[sequence_tag]} 2> {log}"
+    log: "tag_bam.log"
+    run:
+        mode = "sam" if config["read_mapper"] != "ema" else "ema"
+        shell(
+            "blr tagbam"
+            " {input.bam}"
+            " -o {output.bam}"
+            " -f {mode}"
+            " 2> {log}")
 
 
 rule mark_duplicates:

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -45,7 +45,7 @@ def main(args):
                         read.set_tag(tag, match.group("value"), value_type=match.group("type"))
                     summary[f"Reads with tag {tag}"] += 1
                 else:
-                    summary[f"reads without tag {tag}"] += 1
+                    summary[f"Reads without tag {tag}"] += 1
 
             out.write(read)
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -30,7 +30,7 @@ def main(args):
     regex_patterns_dict = dict()
     for tag in args.tags:
         # Make regex expression, compile and save
-        pattern = regex_function(bam_tag=tag)
+        pattern = regex_function(bam_tag=tag, length=args.tag_length)
         compiled_pattern = re.compile(pattern)
         regex_patterns_dict[tag] = compiled_pattern
 
@@ -60,7 +60,7 @@ def main(args):
     logger.info("Finished")
 
 
-def build_regex_sam_tag(bam_tag, allowed_value_chars="ATGCN"):
+def build_regex_sam_tag(bam_tag, allowed_value_chars="ATGCN", length=None):
     """
     Buidls regex string for SAM tags.
     :param bam_tag: str, SAM tag to search for, e.g. BX
@@ -69,7 +69,8 @@ def build_regex_sam_tag(bam_tag, allowed_value_chars="ATGCN"):
     """
 
     # Build regex pattern strings
-    pattern_tag_value = f"[{allowed_value_chars}]+"
+    length_car = "+" if not length else str(length)
+    pattern_tag_value = f"[{allowed_value_chars}]{length_car}"
     pattern_tag_types = f"[{ALLOWED_SAM_TAG_TYPES}]"
 
     # Add strings to name match object variables to match.group(<name>)
@@ -105,3 +106,4 @@ def add_arguments(parser):
     parser.add_argument("--only-remove", action="store_true", help="Only remove tag from header, will set SAM tag.")
     parser.add_argument("--pattern-type", default="sam", choices=["sam"],
                         help="Specify what tag pattern to search for in query headers. Default: %(default)s")
+    parser.add_argument("--tag-length", help="Specify the length of the value in the SAM tag.")

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -38,8 +38,8 @@ def main(args):
 def mode_samtags_underline_separation(read, summary):
     """
     Trims header from tags and sets SAM tags according to values found in header.
-    Assumes format: @header_<tag1>:Z:<seq>_tag2:Z:<seq>. Constrictions are: Header includes exactly three elements
-    separated by "_" and both tags follow SAM format.
+    Assumes format: @header_<tag>:<type>:<seq> (can be numerous tags). Constrictions are: Header includes SAM tags
+    separated by "_".
     :param read: pysam read alignment
     :param summary: Collections's Counter object
     :return:
@@ -68,7 +68,7 @@ def mode_ema(read, summary):
 
     # Strip header
     summary["Total reads"] += 1
-    read.query_name = "".join(query_name.rsplit(":", 1))
+    read.query_name = "".join(query_name.rsplit(":", 1))[0]
 
 
 def add_arguments(parser):

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -43,7 +43,7 @@ def main(args):
                     read.query_name = read.query_name.replace(divider + full_tag_string, "")
                     if not args.only_remove:
                         read.set_tag(tag, match.group("value"), value_type=match.group("type"))
-                    summary[f"reads with tag {tag}"] += 1
+                    summary[f"Reads with tag {tag}"] += 1
                 else:
                     summary[f"reads without tag {tag}"] += 1
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -1,5 +1,6 @@
 """
-Transfers tags from query headers to SAM tags. Currently tags in header must follow SAM tag format, e.g. BC:Z:<SEQUENCE>.
+Transfers SAM tags from query headers to SAM tags. Currently tags in header must follow SAM tag format, e.g.
+BC:Z:<SEQUENCE>.
 """
 
 import pysam

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -69,8 +69,8 @@ def build_regex_sam_tag(bam_tag, allowed_value_chars="ATGCN", length=None):
     """
 
     # Build regex pattern strings
-    length_car = "+" if not length else str(length)
-    pattern_tag_value = f"[{allowed_value_chars}]{length_car}"
+    length_str = "+" if not length else "{" + str(length) + "}"
+    pattern_tag_value = f"[{allowed_value_chars}]{length_str}"
     pattern_tag_types = f"[{ALLOWED_SAM_TAG_TYPES}]"
 
     # Add strings to name match object variables to match.group(<name>)

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -14,20 +14,21 @@ logger = logging.getLogger(__name__)
 
 def main(args):
     # Can't be at top since function are defined later
-    FUNCTION_DICT = {
+    function_dict = {
         "sam": mode_samtags_underline_separation,
         "ema": mode_ema
     }
 
     logger.info("Starting analysis")
     summary = Counter()
-    processing_function = FUNCTION_DICT[args.format]
+    processing_function = function_dict[args.format]
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
     with pysam.AlignmentFile(args.input, "rb") as infile, \
             pysam.AlignmentFile(args.output, "wb", template=infile) as out:
         for read in tqdm(infile.fetch(until_eof=True), desc="Processing reads", unit=" reads"):
             # Strips header from tag and depending on script mode, possibly sets SAM tag
+            summary["Total reads"] += 1
             processing_function(read, summary)
             out.write(read)
 
@@ -46,7 +47,6 @@ def mode_samtags_underline_separation(read, summary):
     """
 
     # Strip header
-    summary["Total reads"] += 1
     header = read.query_name.split("_")
     read.query_name = header[0]
 
@@ -67,7 +67,6 @@ def mode_ema(read, summary):
     """
 
     # Strip header
-    summary["Total reads"] += 1
     read.query_name = read.query_name.rsplit(":", 1)[0]
 
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -68,8 +68,7 @@ def mode_ema(read, summary):
 
     # Strip header
     summary["Total reads"] += 1
-    read.query_name = "".join(query_name.rsplit(":", 1))[0]
-
+    read.query_name = read.query_name.rsplit(":", 1)[0]
 
 def add_arguments(parser):
     parser.add_argument("input",

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -57,7 +57,7 @@ def mode_samtags_underline_separation(read, summary):
         summary[f"Reads with tag {tag}"] += 1
 
 
-def mode_ema(read, summary):
+def mode_ema(read):
     """
     Trims header from barcode sequences.
     Assumes format @header:and:more...:header:<seq>. Constrictions: There must be exactly 9 elements separated by ":"

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -49,7 +49,7 @@ def main(args):
 
             out.write(read)
 
-    print_stats(summary, name="stats")
+    print_stats(summary, name=__name__)
     logger.info("Finished")
 
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -12,12 +12,11 @@ from blr.utils import print_stats
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_BAM_TAG_TYPES = "ABfHiZ" # From SAM format specs https://samtools.github.io/hts-specs/SAMtags.pdf
+ALLOWED_BAM_TAG_TYPES = "ABfHiZ"  # From SAM format specs https://samtools.github.io/hts-specs/SAMtags.pdf
 
 
 def main(args):
     logger.info("Starting analysis")
-    alignments_missing_bc = 0
     summary = Counter()
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
@@ -32,7 +31,7 @@ def main(args):
                 # If tag string is found, remove from header and set SAM tag value
                 if match:
                     full_tag_string = match.group(0)
-                    divider = read.query_name[match.start()-1]
+                    divider = read.query_name[match.start() - 1]
                     read.query_name = read.query_name.replace(divider + full_tag_string, "")
                     read.set_tag(match.group("tag"), match.group("value"), value_type=match.group("type"))
                     summary[f"reads with tag {tag}"] += 1
@@ -62,15 +61,22 @@ def find_tag(header, bam_tag, allowed_value_chars="ATGCN"):
     regex_tag_value = add_regex_name(pattern=pattern_tag_value, name="value")
 
     # regex pattern search for tag:type:value
-    regex_string = r":".join([regex_bam_tag,regex_allowed_types,regex_tag_value])
+    regex_string = r":".join([regex_bam_tag, regex_allowed_types, regex_tag_value])
     return re.search(regex_string, header)
 
 
 def add_regex_name(pattern, name):
+    """
+    Formats a string to fit the regex pattern for getting named match objects
+    :param pattern: str, regex pattern
+    :param name: str
+    :return: named regex string
+    """
     prefix = "(?P<"
     infix = ">"
     suffix = ")"
     return prefix + name + infix + pattern + suffix
+
 
 def add_arguments(parser):
     parser.add_argument("input",

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -26,7 +26,7 @@ def main(args):
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
     with pysam.AlignmentFile(args.input, "rb") as infile, \
             pysam.AlignmentFile(args.output, "wb", template=infile) as out:
-        for read in tqdm(infile.fetch(until_eof=True), desc="Reading input", unit=" reads"):
+        for read in tqdm(infile.fetch(until_eof=True), desc="Processing reads", unit=" reads"):
             # Strips header from tag and depending on script mode, possibly sets SAM tag
             processing_function(read, summary)
             out.write(read)

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -70,6 +70,7 @@ def mode_ema(read, summary):
     summary["Total reads"] += 1
     read.query_name = read.query_name.rsplit(":", 1)[0]
 
+
 def add_arguments(parser):
     parser.add_argument("input",
                         help="BAM file with SAM tag info in header. To read from stdin use '-'.")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -35,5 +35,5 @@ test $m == e6800be93dad0e09c41fd6dcecf68eb9
 blr run phasing_stats.txt
 
 # Cut away columns 2 and 3 as these change order between linux and osx
-m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | sort | md5sum | cut -f1 -d" ")
-test $m2 == 6fd66ab058ea30efdba1c9295bdf2cfc
+m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")
+test $m2 == 70c907df8a996d2b3ba3f06fb942b244

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -28,7 +28,7 @@ blr config \
 
 pushd outdir-bowtie2
 blr run
-m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum)
+m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
 test $m == e6800be93dad0e09c41fd6dcecf68eb9
 
 # Test phasing

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -28,12 +28,12 @@ blr config \
 
 pushd outdir-bowtie2
 blr run
-m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == e389e3f6e8ba14466f232b19fa1a0ee5
+m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | sort | md5sum | cut -f1 -d" ")
+test $m == 5940df8a11377efcbd65a91c42bb058d
 
 # Test phasing
 blr run phasing_stats.txt
 
 # Cut away columns 2 and 3 as these change order between linux and osx
-m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")
-test $m2 == 70c907df8a996d2b3ba3f06fb942b244
+m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | sort | md5sum | cut -f1 -d" ")
+test $m2 == 6fd66ab058ea30efdba1c9295bdf2cfc

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -28,8 +28,8 @@ blr config \
 
 pushd outdir-bowtie2
 blr run
-m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | sort | md5sum | cut -f1 -d" ")
-test $m == 5940df8a11377efcbd65a91c42bb058d
+m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum)
+test $m == e6800be93dad0e09c41fd6dcecf68eb9
 
 # Test phasing
 blr run phasing_stats.txt

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,7 +29,7 @@ blr config \
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == e6800be93dad0e09c41fd6dcecf68eb9
+test $m == 60b2acc02c872c30d8683bd6a9d3568b
 
 # Test phasing
 blr run phasing_stats.txt


### PR DESCRIPTION
Followup PR from #165. **TL;DR:** regex was nice but slow so now it uses split instead.

Now `tagbam` runs in different modes where one can choose `--format sam` or `--format ema` which processes reads differently. 

- `--format sam` splits header on `_` where SAM tags are created from everything found after the first element. This will run any number of SAM tags found in header.

- `--format ema` rsplits once on `:` where the last element is removed. This does not set a SAM tag as it should already be in the alignment produced from EMA.