### PR TITLE
Phasing stats per chromosome

### DIFF
--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -9,13 +9,13 @@ dependencies:
   - blas=2.14=openblas
   - bowtie2=2.3.5=py36he860b03_0
   - bwa=0.7.17=hed695b0_6
-  - bzip2=1.0.8=h516909a_1
+  - bzip2=1.0.8=h516909a_2
   - ca-certificates=2019.11.28=hecc5488_0
   - certifi=2019.11.28=py36_0
   - cffi=1.13.2=py36h8022711_0
   - chardet=3.0.4=py36_1003
   - configargparse=0.13.0=py_1
-  - cryptography=2.8=py36h72c5cf5_0
+  - cryptography=2.8=py36h72c5cf5_1
   - curl=7.65.3=hf8cf82a_0
   - cutadapt=2.5=py36h516909a_0
   - datrie=0.8=py36h516909a_0
@@ -25,13 +25,13 @@ dependencies:
   - freebayes=1.3.1=py36h56106d0_0
   - gitdb2=2.0.6=py_0
   - gitpython=3.0.5=py_0
-  - hapcut2=1.2=hed50d52_0
-  - htslib=1.9=h244ad75_9
+  - hapcut2=1.1=hed695b0_0
+  - htslib=1.10=h78d89cc_1
   - idna=2.8=py36_1000
-  - importlib_metadata=1.1.0=py36_0
+  - importlib_metadata=1.3.0=py36_0
   - importlib_resources=1.0.2=py36_1000
   - jsonschema=3.2.0=py36_0
-  - krb5=1.16.3=h05b26f9_1001
+  - krb5=1.16.4=h2fd8d38_0
   - libblas=3.8.0=14_openblas
   - libcblas=3.8.0=14_openblas
   - libcurl=7.65.3=hda55be3_0
@@ -42,14 +42,16 @@ dependencies:
   - libgfortran-ng=7.3.0=hdf63c60_2
   - liblapack=3.8.0=14_openblas
   - liblapacke=3.8.0=14_openblas
-  - libopenblas=0.3.7=h5ec1e0e_4
+  - libopenblas=0.3.7=h5ec1e0e_5
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_0
   - minimap2=2.17=h8b12597_1
-  - more-itertools=7.2.0=py_0
+  - more-itertools=8.0.2=py_0
   - ncurses=6.1=hf484d3e_1002
   - nomkl=3.0=0
+  - numpy=1.17.3=py36h95a1406_0
   - openssl=1.1.1d=h516909a_0
+  - pandas=0.25.3=py36hb3f55d8_0
   - parallel=20191122=0
   - perl=5.26.2=h516909a_1006
   - pigz=2.3.4=0
@@ -61,7 +63,9 @@ dependencies:
   - pysam=0.15.3=py36hbcae180_3
   - pysocks=1.7.1=py36_0
   - python=3.6.7=h357f687_1006
-  - pyyaml=5.1.2=py36h516909a_1
+  - python-dateutil=2.8.1=py_0
+  - pytz=2019.3=py_0
+  - pyyaml=5.2=py36h516909a_0
   - ratelimiter=1.2.0=py36_1000
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py36_1
@@ -69,23 +73,23 @@ dependencies:
   - ruamel.yaml.clib=0.2.0=py36h516909a_0
   - sambamba=0.6.6=2
   - samblaster=0.1.24=hc9558a2_3
-  - samtools=1.9=h10a08f8_12
+  - samtools=1.10=h9402c20_1
   - setuptools=42.0.2=py36_0
   - six=1.13.0=py36_0
   - smmap2=2.0.5=py_0
-  - snakemake-minimal=5.8.1=py_0
+  - snakemake-minimal=5.8.2=py_0
   - sqlite=3.30.1=hcee41ef_0
   - starcode=1.3=h14c3975_1
   - tbb=2019.9=hc9558a2_1
   - tk=8.6.10=hed695b0_0
-  - tqdm=4.40.0=py_0
+  - tqdm=4.40.2=py_0
   - urllib3=1.25.7=py36_0
   - vcflib=1.0.0_rc2=h56106d0_2
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h516909a_0
   - xopen=0.8.4=py36_0
   - xz=5.2.4=h14c3975_1001
-  - yaml=0.2.2=he1b5a44_0
+  - yaml=0.2.2=h516909a_1
   - zipp=0.6.0=py_0
   - zlib=1.2.11=h516909a_1006
 

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -8,13 +8,13 @@ dependencies:
   - blas=2.14=openblas
   - bowtie2=2.3.5=py36h5c9b4e4_0
   - bwa=0.7.17=h2573ce8_6
-  - bzip2=1.0.8=h01d97ff_1
+  - bzip2=1.0.8=h0b31af3_2
   - ca-certificates=2019.11.28=hecc5488_0
   - certifi=2019.11.28=py36_0
   - cffi=1.13.2=py36h33e799b_0
   - chardet=3.0.4=py36_1003
   - configargparse=0.13.0=py_1
-  - cryptography=2.8=py36hafa8578_0
+  - cryptography=2.8=py36hafa8578_1
   - curl=7.65.3=h22ea746_0
   - cutadapt=2.5=py36h01d97ff_0
   - datrie=0.8=py36h01d97ff_0
@@ -24,13 +24,13 @@ dependencies:
   - freebayes=1.3.1=py36he0122c3_0
   - gitdb2=2.0.6=py_0
   - gitpython=3.0.5=py_0
-  - hapcut2=1.2=hd50730b_0
-  - htslib=1.9=h356306b_9
+  - hapcut2=1.1=h2573ce8_0
+  - htslib=1.10=h862b14c_1
   - idna=2.8=py36_1000
-  - importlib_metadata=1.1.0=py36_0
+  - importlib_metadata=1.3.0=py36_0
   - importlib_resources=1.0.2=py36_1000
   - jsonschema=3.2.0=py36_0
-  - krb5=1.16.3=hcfa6398_1001
+  - krb5=1.16.4=h1752a42_0
   - libblas=3.8.0=14_openblas
   - libcblas=3.8.0=14_openblas
   - libcurl=7.65.3=h16faf7d_0
@@ -41,14 +41,16 @@ dependencies:
   - libgfortran=4.0.0=2
   - liblapack=3.8.0=14_openblas
   - liblapacke=3.8.0=14_openblas
-  - libopenblas=0.3.7=h3d69b6c_4
+  - libopenblas=0.3.7=h3d69b6c_5
   - libssh2=1.8.2=hcdc9a53_2
   - llvm-openmp=9.0.0=h40edb58_0
   - minimap2=2.17=hfbae3c0_1
-  - more-itertools=7.2.0=py_0
+  - more-itertools=8.0.2=py_0
   - ncurses=6.1=h0a44026_1002
   - nomkl=3.0=0
+  - numpy=1.17.3=py36hde6bac1_0
   - openssl=1.1.1d=h0b31af3_0
+  - pandas=0.25.3=py36h4f17bb1_0
   - parallel=20191122=0
   - perl=5.26.2=haec8ef5_1006
   - pigz=2.3.4=0
@@ -60,7 +62,9 @@ dependencies:
   - pysam=0.15.3=py36h4ace0ce_3
   - pysocks=1.7.1=py36_0
   - python=3.6.7=h4285619_1006
-  - pyyaml=5.1.2=py36h0b31af3_1
+  - python-dateutil=2.8.1=py_0
+  - pytz=2019.3=py_0
+  - pyyaml=5.2=py36h0b31af3_0
   - ratelimiter=1.2.0=py36_1000
   - readline=8.0=hcfe32e1_0
   - requests=2.22.0=py36_1
@@ -68,23 +72,23 @@ dependencies:
   - ruamel.yaml.clib=0.2.0=py36h0b31af3_0
   - sambamba=0.6.6=2
   - samblaster=0.1.24=h770b8ee_3
-  - samtools=1.9=h8aa4d43_12
+  - samtools=1.10=h457b48f_1
   - setuptools=42.0.2=py36_0
   - six=1.13.0=py36_0
   - smmap2=2.0.5=py_0
-  - snakemake-minimal=5.8.1=py_0
+  - snakemake-minimal=5.8.2=py_0
   - sqlite=3.30.1=h93121df_0
   - starcode=1.3=h1de35cc_1
   - tbb=2019.9=ha1b3eb9_1
   - tk=8.6.10=hbbe82c9_0
-  - tqdm=4.40.0=py_0
+  - tqdm=4.40.2=py_0
   - urllib3=1.25.7=py36_0
   - vcflib=1.0.0_rc2=he0122c3_2
   - wheel=0.33.6=py36_0
   - wrapt=1.11.2=py36h0b31af3_0
   - xopen=0.8.4=py36_0
   - xz=5.2.4=h1de35cc_1001
-  - yaml=0.2.2=h4a8c4bd_0
+  - yaml=0.2.2=h0b31af3_1
   - zipp=0.6.0=py_0
   - zlib=1.2.11=h0b31af3_1006
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,3 +25,4 @@ dependencies:
   - ruamel.yaml
   - vcflib
   - ema=0.6.2
+  - pandas

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -21,3 +21,4 @@ barcode_len: 20 # Length of barcode sequence
 ####################
 reference_variants: #Path to reference variants used for phasing, if not provided then variant will be called by freebayes
 phasing_ground_truth: #Path to phased variants used for calculating stats
+chromosomes: # Chromosomes for phasing analysis.

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -52,4 +52,6 @@ properties:
   max_molecules_per_bc:
     type: integer
     description: Max number of molecules allowed for a single barcode (removes if bc has > 260 molecules).
-
+  chromosomes:
+    type: ["string", "null"]
+    description: File with chromosomes for phasing analysis. Default is chr1-chr22.

--- a/src/blr/rules/phasing.smk
+++ b/src/blr/rules/phasing.smk
@@ -6,7 +6,7 @@ def chr_from_file(file):
         return [line.strip() for line in f]
 
 # Get list of chromosomes for phasing analysis.
-chromosomes = [f"chr{nr}" for nr in range(22)] if not config["chromosomes"] else chr_from_file(config["chromosomes"])
+chromosomes = [f"chr{nr}" for nr in range(1, 23)] if not config["chromosomes"] else chr_from_file(config["chromosomes"])
 
 
 rule hapcut2_extracthairs:

--- a/src/blr/rules/phasing.smk
+++ b/src/blr/rules/phasing.smk
@@ -84,7 +84,7 @@ rule hapcut2_stats:
             shell("touch {output}")
         else:
             shell(
-                " calculate_haplotype_statistics.py"
+                "calculate_haplotype_statistics.py"
                 " -v1 {input}"
                 " -v2 {config[phasing_ground_truth]}"
                 " > {output}"

--- a/src/blr/rules/phasing.smk
+++ b/src/blr/rules/phasing.smk
@@ -1,5 +1,13 @@
-
+import pandas as pd
 variants = "variants.reference.vcf" if config["reference_variants"] else "variants.called.vcf"
+
+def chr_from_file(file):
+    with open(file) as f:
+        return [line.strip() for line in f]
+
+# Get list of chromosomes for phasing analysis.
+chromosomes = [f"chr{nr}" for nr in range(22)] if not config["chromosomes"] else chr_from_file(config["chromosomes"])
+
 
 rule hapcut2_extracthairs:
     output:
@@ -49,11 +57,31 @@ rule hapcut2_phasing:
          " --outvcf 1 2> {log}"
 
 
+rule bzgip_and_index_vcf:
+    output:
+        vcf = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.vcf.gz",
+        index = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.vcf.gz.tbi"
+    input:
+        vcf = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF"
+    shell:
+        "bgzip -c {input.vcf} > {output.vcf} &&"
+        " tabix -p vcf {output.vcf}"
+
+
+rule split_vcf:
+    output: expand("chromosome_phased_vcf/{chromosome}.phased.vcf", chromosome=chromosomes)
+    input: "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.vcf.gz"
+    run:
+        for chromosome in chromosomes:
+            shell(
+                "tabix {input} {chromosome} > {output}"
+            )
+
 rule hapcut2_stats:
     output:
-        stats = "phasing_stats.txt"
+        stats = "chromosome_phased_vcf/{chromosome}.phasing_stats.txt"
     input:
-         vcf1 = "mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase.phased.VCF",
+         vcf1 = "chromosome_phased_vcf/{chromosome}.phased.vcf"
     params:
           vcf2 = config["phasing_ground_truth"]
     shell:
@@ -61,3 +89,19 @@ rule hapcut2_stats:
          " -v1 {input.vcf1}"
          " -v2 {params.vcf2}"
          " > {output.stats}"
+
+rule aggregate_stats:
+    output: "phasing_stats.csv"
+    input: expand("chromosome_phased_vcf/{chromosome}.phasing_stats.txt", chromosome=chromosomes)
+    run:
+        results = list()
+        for file in input:
+            row = {"chromosome": file.split("/")[1].split(".")[0]}
+            with open(file, "r") as f:
+                for l in f:
+                    if ":" not in l:
+                        continue
+                    row[l.split(":")[0]] = l.split(":")[1].strip()
+            results.append(row)
+        df = pd.DataFrame(results).set_index("chromosome")
+        df.to_csv(output[0])

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,12 +27,17 @@ blr config \
     --set phasing_ground_truth ../testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf
 
 pushd outdir-bowtie2
+
+echo "chr1mini" > genome.fa
+
+blr config --set chromosomes genome.fa
+
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
 test $m == de843a922d50db18d73617df1c9884b5
 
 # Test phasing
-blr run phasing_stats.txt
+blr run phasing_stats.csv
 
 # Cut away columns 2 and 3 as these change order between linux and osx
 m2=$(cut -f1,4- mapped.sorted.tag.mkdup.bcmerge.mol.filt.phase | md5sum | cut -f1 -d" ")


### PR DESCRIPTION
See issue #179 

Added handling for multiple chromosomes in phased VCF file as this cannot be handled by Hapcut2's `calculate_haplotype_statistics.py`. The proposed addition splits the VCF based on chromosomes (specified in config under `chromosomes` as a file or using the default of chr1-chr22). The final output is an CSV file with aggregated statistics for all chromosomes. 