### PR TITLE
Filter out duplicate read in filterclusters

### DIFF
--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -32,28 +32,22 @@ def main(args):
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name
+            barcode = utils.get_bamtag(pysam_read=read, tag=args.barcode_tag)
 
-            # If barcode is not in all_molecules the barcode does not have enough proximal reads to make a single
-            # molecule. If the barcode has more than <max_molecules> molecules, remove it from the read.
-            if name in header_to_mol_dict:
-                summary["Reads tagged"] += 1
-
-                # Set tags
-                molecule_ID = header_to_mol_dict[name]
-                read.set_tag(args.molecule_tag, molecule_ID)
-                bc_num_molecules = len(bc_to_mol_dict[read.get_tag(args.barcode_tag)])
+            # If barcode is not in bc_to_mol_dict the barcode does not have enough proximal reads to make a single
+            # molecule.
+            if barcode in bc_to_mol_dict:
+                summary[f"Reads {args.number_tag} tagged"] += 1
+                bc_num_molecules = len(bc_to_mol_dict[barcode])
                 read.set_tag(args.number_tag, bc_num_molecules)
 
+            # If the read name is in header_to_mol_dict then it is associated to a specific molecule.
+            if name in header_to_mol_dict:
+                summary[f"Reads {args.molecule_tag} tagged"] += 1
+                molecule_ID = header_to_mol_dict[name]
+                read.set_tag(args.molecule_tag, molecule_ID)
+
             openout.write(read)
-
-    non_analyced_keys = (
-        "Overlapping reads in molecule",
-        "Reads without barcode",
-        f"Unmapped {args.barcode_tag} tagged read",
-        "Duplicates"
-    )
-
-    summary["Non analyced reads"] = sum([summary[key] for key in non_analyced_keys])
 
     utils.print_stats(summary, name=__name__)
 
@@ -63,12 +57,35 @@ def main(args):
         write_molecule_stats(bc_to_mol_dict)
 
 
+def parse_reads(pysam_openfile, barcode_tag, summary):
+    for read in tqdm(pysam_openfile.fetch(until_eof=True)):
+        is_good = True
+        summary["Total reads"] += 1
+        if read.is_duplicate:
+            summary["Duplicates"] += 1
+            is_good = False
+
+        barcode = utils.get_bamtag(pysam_read=read, tag=barcode_tag)
+        if not barcode:
+            summary["Reads without barcode"] += 1
+            is_good = False
+
+        if read.is_unmapped and barcode:
+            summary[f"Unmapped {barcode_tag} tagged read"] += 1
+            is_good = False
+
+        if is_good:
+            yield barcode, read
+        else:
+            summary["Non analyced reads"] += 1
+
+
 def build_molecules(pysam_openfile, barcode_tag, window, min_reads, summary):
     """
     Builds all_molecules.bc_to_mol ([barcode][moleculeID] = molecule) and
     all_molecules.header_to_mol ([read_name]=mol_ID)
     :param pysam_openfile: Pysam open file instance.
-    :param barcode_tag: Tag used to store barcode in bam file (usually BC).
+    :param barcode_tag: Tag used to store barcode in bam file.
     :param window: Max distance between reads to include in the same molecule.
     :param min_reads: Minimum reads to include molecule in all_molecules.bc_to_mol
     :param summary: dict for stats collection
@@ -79,48 +96,37 @@ def build_molecules(pysam_openfile, barcode_tag, window, min_reads, summary):
 
     prev_chrom = pysam_openfile.references[0]
     logger.info("Dividing barcodes into molecules")
-    for read in tqdm(pysam_openfile.fetch(until_eof=True)):
-        summary["Total reads"] += 1
-        if read.is_duplicate:
-            summary["Duplicates"] += 1
-            continue
+    for barcode, read in parse_reads(pysam_openfile, barcode_tag, summary):
+        read_start = read.reference_start
+        read_stop = read.reference_end
 
-        # Fetches barcode and genomic position. Position will be formatted so start < stop.
-        barcode = utils.get_bamtag(pysam_read=read, tag=barcode_tag)
-        if not barcode:
-            summary["Reads without barcode"] += 1
-        elif read.is_unmapped:
-            summary[f"Unmapped {barcode_tag} tagged read"] += 1
-        else:
-            read_start, read_stop = sorted((read.reference_start, read.reference_end))
+        # Commit molecules between chromosomes
+        if not prev_chrom == read.reference_name:
+            all_molecules.report_and_remove_all()
+            prev_chrom = read.reference_name
 
-            # Commit molecules between chromosomes
-            if not prev_chrom == read.reference_name:
-                all_molecules.report_and_remove_all()
-                prev_chrom = read.reference_name
+        if barcode in all_molecules.cache_dict:
+            molecule = all_molecules.cache_dict[barcode]
 
-            if barcode in all_molecules.cache_dict:
-                molecule = all_molecules.cache_dict[barcode]
-
-                # Read is within window => add read to molecule (don't include overlapping reads).
-                if (molecule.stop + window) >= read_start:
-                    if molecule.stop >= read_start and read.query_name not in molecule.read_headers:
-                        summary["Overlapping reads in molecule"] += 1
-                    else:
-                        molecule.add_read(stop=read_stop, read_header=read.query_name)
-                        all_molecules.cache_dict[barcode] = molecule
-
-                # Read is not within window => report old and initiate new molecule for that barcode.
+            # Read is within window => add read to molecule (don't include overlapping reads).
+            if (molecule.stop + window) >= read_start:
+                if molecule.stop >= read_start and read.query_name not in molecule.read_headers:
+                    summary["Overlapping reads in molecule"] += 1
                 else:
-                    all_molecules.report(molecule=molecule)
-                    all_molecules.terminate(molecule=molecule)
+                    molecule.add_read(stop=read_stop, read_header=read.query_name)
+                    all_molecules.cache_dict[barcode] = molecule
 
-                    molecule = Molecule(barcode=barcode, start=read_start, stop=read_stop, read_header=read.query_name)
-                    all_molecules.cache_dict[molecule.barcode] = molecule
-
+            # Read is not within window => report old and initiate new molecule for that barcode.
             else:
+                all_molecules.report(molecule=molecule)
+                all_molecules.terminate(molecule=molecule)
+
                 molecule = Molecule(barcode=barcode, start=read_start, stop=read_stop, read_header=read.query_name)
                 all_molecules.cache_dict[molecule.barcode] = molecule
+
+        else:
+            molecule = Molecule(barcode=barcode, start=read_start, stop=read_stop, read_header=read.query_name)
+            all_molecules.cache_dict[molecule.barcode] = molecule
 
     all_molecules.report_and_remove_all()
 
@@ -145,9 +151,7 @@ class Molecule:
         self.barcode = barcode
         self.start = start
         self.stop = stop
-        self.read_headers = set()
-        self.read_headers.add(read_header)
-
+        self.read_headers = {read_header}
         self.number_of_reads = 1
 
         Molecule.molecule_counter += 1

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -37,15 +37,18 @@ def main(args):
             # If barcode is not in bc_to_mol_dict the barcode does not have enough proximal reads to make a single
             # molecule.
             if barcode in bc_to_mol_dict:
-                summary[f"Output reads {args.number_tag} tagged"] += 1
                 bc_num_molecules = len(bc_to_mol_dict[barcode])
                 read.set_tag(args.number_tag, bc_num_molecules)
+            else:
+                read.set_tag(args.number_tag, 0)
 
             # If the read name is in header_to_mol_dict then it is associated to a specific molecule.
             if name in header_to_mol_dict:
-                summary[f"Output reads {args.molecule_tag} tagged"] += 1
                 molecule_ID = header_to_mol_dict[name]
                 read.set_tag(args.molecule_tag, molecule_ID)
+            else:
+                # For reads not associated to a specific molecule the molecule id is set to -1.
+                read.set_tag(args.molecule_tag, -1)
 
             openout.write(read)
 
@@ -70,8 +73,8 @@ def parse_reads(pysam_openfile, barcode_tag, summary):
             summary["Reads without barcode"] += 1
             is_good = False
 
-        if read.is_unmapped and barcode:
-            summary[f"Unmapped {barcode_tag} tagged read"] += 1
+        if read.is_unmapped:
+            summary[f"Unmapped reads"] += 1
             is_good = False
 
         if is_good:

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -37,13 +37,13 @@ def main(args):
             # If barcode is not in bc_to_mol_dict the barcode does not have enough proximal reads to make a single
             # molecule.
             if barcode in bc_to_mol_dict:
-                summary[f"Reads {args.number_tag} tagged"] += 1
+                summary[f"Output reads {args.number_tag} tagged"] += 1
                 bc_num_molecules = len(bc_to_mol_dict[barcode])
                 read.set_tag(args.number_tag, bc_num_molecules)
 
             # If the read name is in header_to_mol_dict then it is associated to a specific molecule.
             if name in header_to_mol_dict:
-                summary[f"Reads {args.molecule_tag} tagged"] += 1
+                summary[f"Output reads {args.molecule_tag} tagged"] += 1
                 molecule_ID = header_to_mol_dict[name]
                 read.set_tag(args.molecule_tag, molecule_ID)
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -33,7 +33,8 @@ def main(args):
                 summary["Removed tags"] += len(tags_to_remove)
                 summary["Reads with removed tags"] += 1
 
-                strip_barcode(pysam_read=read, tags_to_be_removed=tags_to_remove, removed_tags=removed_tags)
+                strip_barcode(pysam_read=read, tags_to_be_removed=tags_to_remove, removed_tags=removed_tags,
+                              summary=summary)
 
             openout.write(read)
 
@@ -44,7 +45,7 @@ def main(args):
     utils.print_stats(summary, name=__name__)
 
 
-def strip_barcode(pysam_read, tags_to_be_removed, removed_tags):
+def strip_barcode(pysam_read, tags_to_be_removed, removed_tags, summary):
     """
     Strips an alignment from its barcode sequence. Keeps information in header but adds FILTERED prior to bc info.
     """
@@ -54,9 +55,12 @@ def strip_barcode(pysam_read, tags_to_be_removed, removed_tags):
 
     # Remove tags
     for bam_tag in tags_to_be_removed:
-        removed_tags[bam_tag].add(pysam_read.get_tag(bam_tag))
-        # Strip read from tag
-        pysam_read.set_tag(bam_tag, None, value_type="Z")
+
+        if pysam_read.has_tag(bam_tag):
+            removed_tags[bam_tag].add(pysam_read.get_tag(bam_tag))
+            # Strip read from tag
+            pysam_read.set_tag(bam_tag, None, value_type="Z")
+            summary[f"Total {bam_tag} tags removed"] += 1
 
 
 def add_arguments(parser):

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -22,7 +22,7 @@ def main(args):
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
             pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
-        for read in tqdm(openin.fetch(until_eof=True)):
+        for read in tqdm(openin.fetch(until_eof=True), desc="Filtering input", unit="reads"):
             summary["Total reads"] += 1
             no_mols = utils.get_bamtag(pysam_read=read, tag=args.number_tag)
 
@@ -33,8 +33,7 @@ def main(args):
                 summary["Removed tags"] += len(tags_to_remove)
                 summary["Reads with removed tags"] += 1
 
-                strip_barcode(pysam_read=read, tags_to_be_removed=tags_to_remove, removed_tags=removed_tags,
-                              summary=summary)
+                strip_barcode(pysam_read=read, tags_to_be_removed=tags_to_remove, removed_tags=removed_tags)
 
             openout.write(read)
 
@@ -45,7 +44,7 @@ def main(args):
     utils.print_stats(summary, name=__name__)
 
 
-def strip_barcode(pysam_read, tags_to_be_removed, removed_tags, summary):
+def strip_barcode(pysam_read, tags_to_be_removed, removed_tags):
     """
     Strips an alignment from its barcode sequence. Keeps information in header but adds FILTERED prior to bc info.
     """
@@ -55,12 +54,9 @@ def strip_barcode(pysam_read, tags_to_be_removed, removed_tags, summary):
 
     # Remove tags
     for bam_tag in tags_to_be_removed:
-
-        if pysam_read.has_tag(bam_tag):
-            removed_tags[bam_tag].add(pysam_read.get_tag(bam_tag))
-            # Strip read from tag
-            pysam_read.set_tag(bam_tag, None, value_type="Z")
-            summary[f"Total {bam_tag} tags removed"] += 1
+        removed_tags[bam_tag].add(pysam_read.get_tag(bam_tag))
+        # Strip read from tag
+        pysam_read.set_tag(bam_tag, None, value_type="Z")
 
 
 def add_arguments(parser):

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,7 +30,7 @@ blr config \
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == c77345c6d1bf14e1650f58f5d3296f10
+test $m == 92f61fee39508beadb96f018a6ceac49
 
 # Test phasing
 blr run phasing_stats.txt

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,7 +30,7 @@ blr config \
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == 1e72392899fdd86654def81fbd1ccd15
+test $m == c77345c6d1bf14e1650f58f5d3296f10
 
 # Test phasing
 blr run phasing_stats.txt

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -24,12 +24,13 @@ blr config \
     --file outdir-bowtie2/blr.yaml \
     --set genome_reference ../testdata/chr1mini.fasta \
     --set reference_variants ../testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf \
-    --set phasing_ground_truth ../testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf
+    --set phasing_ground_truth ../testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf \
+    --set max_molecules_per_bc 1
 
 pushd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam | md5sum | cut -f1 -d" ")
-test $m == 60b2acc02c872c30d8683bd6a9d3568b
+test $m == 1e72392899fdd86654def81fbd1ccd15
 
 # Test phasing
 blr run phasing_stats.txt


### PR DESCRIPTION
Solves #178 

Change tagging routine in `buildmolecules` so that even duplicate read will get the number_tag (MN). This ensures that they will be filtered out correctly in the `filterclusters` step. 

Other edits:
- Refactored `buildmolecules`
- Change test config so that `filterclusters` is properly tested. 
- Updated `filterclusters` to handle duplicate reads that have the MN tag but not the MI tag.  