### PR TITLE
Add processing information to BAM header.

### DIFF
--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -9,6 +9,7 @@ import pysam
 import logging
 from collections import Counter
 from tqdm import tqdm
+import sys
 
 from blr import utils
 
@@ -26,9 +27,10 @@ def main(args):
                                                              min_reads=args.threshold,
                                                              summary=summary)
 
+    header = utils.create_header(args.input, __name__, sys.argv)
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
+            pysam.AlignmentFile(args.output, "wb", header=header) as openout:
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -9,7 +9,6 @@ import pysam
 import logging
 from collections import Counter
 from tqdm import tqdm
-import sys
 
 from blr import utils
 
@@ -27,7 +26,7 @@ def main(args):
                                                              min_reads=args.threshold,
                                                              summary=summary)
 
-    header = utils.create_header(args.input, __name__, sys.argv)
+    header = utils.create_header(args.input, __name__)
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
             pysam.AlignmentFile(args.output, "wb", header=header) as openout:

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -13,6 +13,7 @@ import pysam
 import logging
 from tqdm import tqdm
 from collections import Counter, deque, OrderedDict
+import sys
 
 from blr import utils
 
@@ -63,12 +64,13 @@ def main(args):
     # Remove several step redundancy (5 -> 3, 3 -> 1) => (5 -> 1, 3 -> 1)
     reduce_several_step_redundancy(merge_dict)
     summary["Barcodes removed"] = len(merge_dict)
+    header = utils.create_header(args.input, __name__, sys.argv)
 
     # Write outputs
     barcodes_written = set()
     with open(args.merge_log, "w") as bc_merge_file, \
             pysam.AlignmentFile(args.input, "rb") as infile, \
-            pysam.AlignmentFile(args.output, "wb", template=infile) as out:
+            pysam.AlignmentFile(args.output, "wb", header=header) as out:
         print(f"Previous_barcode,New_barcode", file=bc_merge_file)
         for read in tqdm(infile.fetch(until_eof=True), desc="Writing output", total=summary["Total reads"]):
 

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -13,7 +13,6 @@ import pysam
 import logging
 from tqdm import tqdm
 from collections import Counter, deque, OrderedDict
-import sys
 
 from blr import utils
 
@@ -64,7 +63,7 @@ def main(args):
     # Remove several step redundancy (5 -> 3, 3 -> 1) => (5 -> 1, 3 -> 1)
     reduce_several_step_redundancy(merge_dict)
     summary["Barcodes removed"] = len(merge_dict)
-    header = utils.create_header(args.input, __name__, sys.argv)
+    header = utils.create_header(args.input, __name__)
 
     # Write outputs
     barcodes_written = set()

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -7,7 +7,6 @@ import pysam
 import logging
 from collections import Counter
 from tqdm import tqdm
-import sys
 
 from blr import utils
 
@@ -19,7 +18,7 @@ def main(args):
     removed_tags = {tag: set() for tag in tags_to_remove}
     summary = Counter()
     logger.info("Starting")
-    header = utils.create_header(args.input, __name__, sys.argv)
+    header = utils.create_header(args.input, __name__)
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
             pysam.AlignmentFile(args.output, "wb", header=header) as openout:

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -7,6 +7,7 @@ import pysam
 import logging
 from collections import Counter
 from tqdm import tqdm
+import sys
 
 from blr import utils
 
@@ -18,10 +19,10 @@ def main(args):
     removed_tags = {tag: set() for tag in tags_to_remove}
     summary = Counter()
     logger.info("Starting")
-
+    header = utils.create_header(args.input, __name__, sys.argv)
     # Writes filtered out
     with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
+            pysam.AlignmentFile(args.output, "wb", header=header) as openout:
         for read in tqdm(openin.fetch(until_eof=True)):
             summary["Total reads"] += 1
             no_mols = utils.get_bamtag(pysam_read=read, tag=args.number_tag)

--- a/src/blr/cli/get.py
+++ b/src/blr/cli/get.py
@@ -6,8 +6,9 @@ import logging
 from collections import Counter
 from tqdm import tqdm
 import os
+import sys
 
-from blr.utils import get_bamtag, print_stats
+from blr.utils import get_bamtag, print_stats, create_header
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +20,10 @@ def main(args):
     values = get_values(args.values)
     counts = {value: 0 for value in values}
     summary["Values to collect"] = len(values)
+    header = create_header(args.input, __name__, sys.argv)
 
     with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", template=openin) as openout:
+            pysam.AlignmentFile(args.output, "wb", header=header) as openout:
         for read in tqdm(openin.fetch(until_eof=True), desc="Processing reads"):
             summary["Reads in"] += 1
             value = get_bamtag(read, args.tag)

--- a/src/blr/cli/get.py
+++ b/src/blr/cli/get.py
@@ -6,7 +6,6 @@ import logging
 from collections import Counter
 from tqdm import tqdm
 import os
-import sys
 
 from blr.utils import get_bamtag, print_stats, create_header
 
@@ -20,7 +19,7 @@ def main(args):
     values = get_values(args.values)
     counts = {value: 0 for value in values}
     summary["Values to collect"] = len(values)
-    header = create_header(args.input, __name__, sys.argv)
+    header = create_header(args.input, __name__)
 
     with pysam.AlignmentFile(args.input, "rb") as openin, \
             pysam.AlignmentFile(args.output, "wb", header=header) as openout:

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -5,7 +5,7 @@ Strips headers from tags and depending on mode, set the appropriate SAM tag.
 import pysam
 import logging
 from tqdm import tqdm
-from collections import Counter, OrderedDict
+from collections import Counter
 import sys
 
 from blr.utils import print_stats, create_header

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -5,9 +5,10 @@ Strips headers from tags and depending on mode, set the appropriate SAM tag.
 import pysam
 import logging
 from tqdm import tqdm
-from collections import Counter
+from collections import Counter, OrderedDict
+import sys
 
-from blr.utils import print_stats
+from blr.utils import print_stats, create_header
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +23,11 @@ def main(args):
     logger.info("Starting analysis")
     summary = Counter()
     processing_function = function_dict[args.format]
+    header = create_header(args.input, __name__, sys.argv)
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
     with pysam.AlignmentFile(args.input, "rb") as infile, \
-            pysam.AlignmentFile(args.output, "wb", template=infile) as out:
+            pysam.AlignmentFile(args.output, "wb", header=header) as out:
         for read in tqdm(infile.fetch(until_eof=True), desc="Processing reads", unit=" reads"):
             # Strips header from tag and depending on script mode, possibly sets SAM tag
             summary["Total reads"] += 1

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -6,7 +6,6 @@ import pysam
 import logging
 from tqdm import tqdm
 from collections import Counter
-import sys
 
 from blr.utils import print_stats, create_header
 
@@ -23,7 +22,7 @@ def main(args):
     logger.info("Starting analysis")
     summary = Counter()
     processing_function = function_dict[args.format]
-    header = create_header(args.input, __name__, sys.argv)
+    header = create_header(args.input, __name__)
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
     with pysam.AlignmentFile(args.input, "rb") as infile, \

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 import sys
+import pysam
 
 
 def is_1_2(s, t):
@@ -76,3 +77,45 @@ def print_stats(summary, name=None, value_width=15, print_to=sys.stderr):
         print(f"{name:<{max_name_width}} {value:>{value_width},}", file=print_to)
 
     print("="*width, file=print_to)
+
+
+def create_header(file, name, argv):
+    """
+    Create SAM header dict with new tool and command line argument information based on template file. Appends new PG
+    entry with tool name (ID), software name (PN), command line arguments (CL) to track the tools applied to the file.
+    Use in output SAM/BAM file as 'header' attribute.
+
+    :param file: string for SAM/BAM file
+    :param name: string '__name__' variable.
+    :param argv: list of arguments from sys.argv
+    :return: dict
+    """
+    def check_name(basename, prev_entries):
+        nr = 0
+        newname = basename
+        while any(newname == e["ID"] for e in prev_entries):
+            nr += 1
+            newname = "_".join([basename, str(nr)])
+        return newname
+
+    id_name = name.split(".")[-1]
+    program_name = name.split(".")[0]
+    cmd_line = f"\"{' '.join(argv)}\""
+
+    with pysam.AlignmentFile(file, "rb") as template:
+        header = template.header.to_dict()
+        pg_entries = header["PG"]
+
+        # Check that id is unique and does not appear in header, otherwise add number at end.
+        id_name = check_name(id_name, pg_entries)
+
+        # TODO add version information (VN tag).
+        pg_entries.append({
+            "ID": id_name,          # Program record identifier. Must be unique
+            "PN": program_name,     # Program name
+            "CL": cmd_line          # Command line
+        })
+
+        header["PG"] = pg_entries
+
+    return pysam.AlignmentHeader.from_dict(header)


### PR DESCRIPTION
I implemented a utility function that can add processing information to the BAM header. Currently this will add information about the program used (blr), the tool used (tagbam, clusterrmdup, etc.) and the command line .. command? (e.g. what was executed). Below is an example with the header from the final `*filt.bam` file. Note that the order of execution of each command is also maintained. What I would like to add later on is some kind of version number for the program. 

This addition will make it easy to track the exact processing performed on any BAM file, even should it be renamed.  

**Example. samtools view -H mapped.sorted.tag.mkdup.bcmerge.mol.filt.bam**
```  
@HD	VN:1.0	SO:coordinate
@SQ	SN:chr1mini	LN:100001
@PG	PN:bowtie2	ID:bowtie2	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/bowtie2-align-s --wrapper basic-0 -p 4 --reorder --maxins 2000 -x ../testdata/chr1mini.fasta -1 trimmed.barcoded.1.fastq.gz -2 trimmed.barcoded.2.fastq.gz"	VN:2.3.5
@PG	PN:blr	ID:tagbam	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/blr tagbam mapped.sorted.bam -o mapped.sorted.tag.bam -f sam"
@PG	ID:sambamba	CL:markdup -t 4 mapped.sorted.tag.bam mapped.sorted.tag.mkdup.bam	PP:tagbam	VN:0.6.6
@PG	PN:blr	ID:clusterrmdup	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/blr clusterrmdup mapped.sorted.tag.mkdup.bam barcode-merges.csv -o mapped.sorted.tag.mkdup.bcmerge.bam -b BX"
@PG	PN:blr	ID:buildmolecules	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/blr buildmolecules mapped.sorted.tag.mkdup.bcmerge.bam -o mapped.sorted.tag.mkdup.bcmerge.mol.bam --stats-files -m MI -n MN -b BX"
@PG	PN:blr	ID:filterclusters	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/blr filterclusters mapped.sorted.tag.mkdup.bcmerge.mol.bam -m MI -n MN -b BX -M 260"
```