### PR TITLE
Add filegraph to run command.

### DIFF
--- a/src/blr/cli/run.py
+++ b/src/blr/cli/run.py
@@ -28,9 +28,16 @@ def add_arguments(parser):
         help='If one job fails, finish the others.')
     arg('--unlock', default=False, action='store_true',
         help='Remove a lock on the working directory.')
-    arg("--dag", default=False, action='store_true',
+    dags = parser.add_mutually_exclusive_group()
+    dags.add_argument(
+        "--dag", default=False, action='store_true',
         help="Print the dag in the graphviz dot language (requires graphviz to be installed). Default: %(default)s. "
              "To get output to pdf file, pipe output into dot as follows: blr run --dag | dot -Tpdf > dag.pdf")
+    dags.add_argument(
+        "--filegraph", default=False, action='store_true',
+        help="Print the file graph showing input/output file from rules in the graphviz dot language (requires "
+             "graphviz to be installed). Default: %(default)s. To get output to pdf file, pipe output into dot "
+             "as follows: blr run --filegraph | dot -Tpdf > filegraph.pdf")
     arg('targets', nargs='*', default=[],
         help='File(s) to create. If omitted, the full pipeline is run.')
 
@@ -38,7 +45,7 @@ def add_arguments(parser):
 def main(args):
     targets = args.targets if args.targets else None
     try:
-        run(args.dryrun, args.cores, args.keepgoing, args.unlock, args.dag, targets)
+        run(args.dryrun, args.cores, args.keepgoing, args.unlock, args.dag, args.filegraph, targets)
     except SnakemakeError:
         sys.exit(1)
     sys.exit(0)
@@ -50,6 +57,7 @@ def run(
     keepgoing: bool = False,
     unlock: bool = False,
     printdag: bool = False,
+    printfilegraph: bool = False,
     targets=None,
     workdir=None,
 ):
@@ -67,6 +75,7 @@ def run(
             unlock=unlock,
             printshellcmds=True,
             printdag=printdag,
+            printfilegraph=printfilegraph,
             targets=targets,
             workdir=workdir,
         )


### PR DESCRIPTION
Solves #186.

Filegraph can show input and output file for the rules in the pipeline.