### PR TITLE
Fix streaming issue from PR#185

### DIFF
--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -10,7 +10,7 @@ import logging
 from collections import Counter
 from tqdm import tqdm
 
-from blr import utils
+from blr.utils import PySAMIO, get_bamtag, print_stats
 
 logger = logging.getLogger(__name__)
 
@@ -25,15 +25,12 @@ def main(args):
                                                              window=args.window,
                                                              min_reads=args.threshold,
                                                              summary=summary)
-
-    header = utils.create_header(args.input, __name__)
     # Writes filtered out
-    with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", header=header) as openout:
+    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (openin, openout):
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name
-            barcode = utils.get_bamtag(pysam_read=read, tag=args.barcode_tag)
+            barcode = get_bamtag(pysam_read=read, tag=args.barcode_tag)
 
             # If barcode is not in bc_to_mol_dict the barcode does not have enough proximal reads to make a single
             # molecule.
@@ -53,7 +50,7 @@ def main(args):
 
             openout.write(read)
 
-    utils.print_stats(summary, name=__name__)
+    print_stats(summary, name=__name__)
 
     # Write molecule/barcode file stats
     if args.stats_files:
@@ -69,7 +66,7 @@ def parse_reads(pysam_openfile, barcode_tag, summary):
             summary["Duplicates"] += 1
             is_good = False
 
-        barcode = utils.get_bamtag(pysam_read=read, tag=barcode_tag)
+        barcode = get_bamtag(pysam_read=read, tag=barcode_tag)
         if not barcode:
             summary["Reads without barcode"] += 1
             is_good = False

--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -26,7 +26,7 @@ def main(args):
                                                              min_reads=args.threshold,
                                                              summary=summary)
     # Writes filtered out
-    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (openin, openout):
+    with PySAMIO(args.input, args.output, __name__) as (openin, openout):
         logger.info("Writing filtered bam file")
         for read in tqdm(openin.fetch(until_eof=True)):
             name = read.query_name

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -66,7 +66,7 @@ def main(args):
 
     # Write outputs
     barcodes_written = set()
-    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (infile, out), \
+    with PySAMIO(args.input, args.output, __name__) as (infile, out), \
             open(args.merge_log, "w") as bc_merge_file:
         print(f"Previous_barcode,New_barcode", file=bc_merge_file)
         for read in tqdm(infile.fetch(until_eof=True), desc="Writing output", total=summary["Total reads"]):

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -19,7 +19,7 @@ def main(args):
     logger.info("Starting")
 
     # Writes filtered out
-    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (openin, openout):
+    with PySAMIO(args.input, args.output, __name__) as (openin, openout):
         for read in tqdm(openin.fetch(until_eof=True), desc="Filtering input", unit="reads"):
             summary["Total reads"] += 1
             no_mols = get_bamtag(pysam_read=read, tag=args.number_tag)

--- a/src/blr/cli/get.py
+++ b/src/blr/cli/get.py
@@ -19,7 +19,7 @@ def main(args):
     counts = {value: 0 for value in values}
     summary["Values to collect"] = len(values)
 
-    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (openin, openout):
+    with PySAMIO(args.input, args.output, __name__) as (openin, openout):
         for read in tqdm(openin.fetch(until_eof=True), desc="Processing reads"):
             summary["Reads in"] += 1
             value = get_bamtag(read, args.tag)

--- a/src/blr/cli/get.py
+++ b/src/blr/cli/get.py
@@ -1,13 +1,12 @@
 """
 Filter BAM for select SAM tag values.
 """
-import pysam
 import logging
 from collections import Counter
 from tqdm import tqdm
 import os
 
-from blr.utils import get_bamtag, print_stats, create_header
+from blr.utils import get_bamtag, print_stats, PySAMIO
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +18,8 @@ def main(args):
     values = get_values(args.values)
     counts = {value: 0 for value in values}
     summary["Values to collect"] = len(values)
-    header = create_header(args.input, __name__)
 
-    with pysam.AlignmentFile(args.input, "rb") as openin, \
-            pysam.AlignmentFile(args.output, "wb", header=header) as openout:
+    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (openin, openout):
         for read in tqdm(openin.fetch(until_eof=True), desc="Processing reads"):
             summary["Reads in"] += 1
             value = get_bamtag(read, args.tag)

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -23,7 +23,7 @@ def main(args):
     processing_function = function_dict[args.format]
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
-    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (infile, outfile):
+    with PySAMIO(args.input, args.output, __name__) as (infile, outfile):
         for read in tqdm(infile.fetch(until_eof=True), desc="Processing reads", unit=" reads"):
             # Strips header from tag and depending on script mode, possibly sets SAM tag
             summary["Total reads"] += 1

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -2,12 +2,11 @@
 Strips headers from tags and depending on mode, set the appropriate SAM tag.
 """
 
-import pysam
 import logging
 from tqdm import tqdm
 from collections import Counter
 
-from blr.utils import print_stats, create_header
+from blr.utils import print_stats, PySAMIO
 
 logger = logging.getLogger(__name__)
 
@@ -22,16 +21,14 @@ def main(args):
     logger.info("Starting analysis")
     summary = Counter()
     processing_function = function_dict[args.format]
-    header = create_header(args.input, __name__)
 
     # Read SAM/BAM files and transfer barcode information from alignment name to SAM tag
-    with pysam.AlignmentFile(args.input, "rb") as infile, \
-            pysam.AlignmentFile(args.output, "wb", header=header) as out:
+    with PySAMIO(args.input, "rb", args.output, "wb", __name__) as (infile, outfile):
         for read in tqdm(infile.fetch(until_eof=True), desc="Processing reads", unit=" reads"):
             # Strips header from tag and depending on script mode, possibly sets SAM tag
             summary["Total reads"] += 1
             processing_function(read, summary)
-            out.write(read)
+            outfile.write(read)
 
     print_stats(summary, name=__name__)
     logger.info("Finished")

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -103,9 +103,9 @@ class PySAMIO:
 
     def _make_header(self, name):
         """
-        Create SAM header dict with new tool and command line argument information based on template file. Appends new PG
-        entry with tool name (ID), software name (PN), command line arguments (CL) to track the tools applied to the file.
-        Use in output SAM/BAM file as 'header' attribute.
+        Create SAM header dict with new tool and command line argument information based on template file. Appends
+        new PG entry with tool name (ID), software name (PN), command line arguments (CL) to track the tools applied
+        to the file. Use in output SAM/BAM file as 'header' attribute.
 
         :param name: string. Pass '__name__' variable to be used to get program and tool name.
         :return: pysam.AlignmentHeader object

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -82,13 +82,13 @@ def print_stats(summary, name=None, value_width=15, print_to=sys.stderr):
 class PySAMIO:
     """ Reader and writer for BAM/SAM files that automatically attaches processing step information to header """
 
-    def __init__(self, inname: str, inmode: str, outname: str, outmode: str, name: str):
+    def __init__(self, inname: str, outname: str, name: str, inmode: str = "rb", outmode: str = "wb"):
         """
         :param inname: Path to input SAM/BAM file.
-        :param inmode: Reading mode for input file. 'r' for SAM and 'rb' for BAM.
         :param outname: Path to output SAM/BAM file.
-        :param outmode: Reading mode for output file. 'r' for SAM and 'rb' for BAM.
         :param name: __name__ variable from script.
+        :param inmode: Reading mode for input file. 'r' for SAM and 'rb' for BAM.
+        :param outmode: Reading mode for output file. 'r' for SAM and 'rb' for BAM.
         """
         self.infile = pysam.AlignmentFile(inname, inmode)
         self.header = self._make_header(name)


### PR DESCRIPTION
PR #185 modifies the headers of output SAM/BAM files with processing information. This was done separately from the reading of the file in the processing script so the file would have to be read twice in order to get the new header and read the file. This is not great if we would like to stream files. Thus I have here added a combined reader/writer class that enables streaming.  