### PR TITLE
10x Chromium linked-reads integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
   - conda update -q conda
   - conda config --add channels bioconda --add channels conda-forge
   - conda info -a
-  - wget https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.2.1.tar.gz
-  - tar xf blr-testdata-0.2.1.tar.gz
-  - ln -s blr-testdata-0.2.1 testdata
+  - wget https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.3.tar.gz
+  - tar xf blr-testdata-0.3.tar.gz
+  - ln -s blr-testdata-0.3 testdata
 
 install:
   - conda env create -n testenv -f environment.${TRAVIS_OS_NAME}.lock.yml

--- a/environment.linux.lock.yml
+++ b/environment.linux.lock.yml
@@ -30,11 +30,11 @@ dependencies:
   - dnaio=0.4.1=py36h516909a_0
   - docutils=0.16=py36_0
   - ema=0.6.2=h8b12597_1
-  - expat=2.2.5=he1b5a44_1004
-  - fastqc=0.11.8=2
+  - expat=2.2.9=he1b5a44_1
+  - fastqc=0.11.9=0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - fontconfig=2.13.1=h86ecdb6_1001
-  - freebayes=1.3.3=py36hc088bd4_0
+  - freebayes=1.3.2=py36hc088bd4_0
   - freetype=2.10.0=he983fc9_1
   - future=0.18.2=py36_0
   - gatk4=4.1.4.1=1
@@ -43,17 +43,19 @@ dependencies:
   - gitpython=3.0.5=py_0
   - glib=2.58.3=py36h6f030ca_1002
   - gsl=2.5=h294904e_1
-  - gst-plugins-base=1.14.5=h0935bb2_0
-  - gstreamer=1.14.5=h36ae1b5_0
+  - gst-plugins-base=1.14.5=h0935bb2_1
+  - gstreamer=1.14.5=h36ae1b5_1
   - hapcut2=1.2=hed50d52_0
   - htslib=1.9=h4da6232_3
   - humanfriendly=4.18=py36_1
   - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
-  - importlib_metadata=1.4.0=py36_0
+  - importlib_metadata=1.5.0=py36_0
   - importlib_resources=1.0.2=py36_1000
+  - inflect=4.0.0=py36_1
   - ipython_genutils=0.2.0=py_1
-  - jinja2=2.10.3=py_0
+  - jaraco.itertools=5.0.0=py_0
+  - jinja2=2.11.0=py_0
   - jpeg=9c=h14c3975_1001
   - jsonschema=3.2.0=py36_0
   - jupyter_core=4.6.1=py36_0
@@ -102,7 +104,7 @@ dependencies:
   - pcre=8.43=he1b5a44_0
   - perl=5.26.2=h516909a_1006
   - pigz=2.3.4=0
-  - pip=20.0.1=py36_0
+  - pip=20.0.2=py36_0
   - psutil=5.6.7=py36h516909a_0
   - pthread-stubs=0.4=h14c3975_1001
   - pycparser=2.19=py36_1
@@ -136,18 +138,18 @@ dependencies:
   - tk=8.6.10=hed695b0_0
   - toposort=1.5=py_3
   - tornado=6.0.3=py36h516909a_0
-  - tqdm=4.41.1=py_0
+  - tqdm=4.42.0=py_0
   - traitlets=4.3.3=py36_0
   - urllib3=1.25.7=py36_0
   - vcflib=1.0.0_rc2=h56106d0_2
-  - wheel=0.33.6=py36_0
+  - wheel=0.34.1=py36_0
   - wrapt=1.11.2=py36h516909a_0
   - xopen=0.8.4=py36_0
   - xorg-libxau=1.0.9=h14c3975_0
   - xorg-libxdmcp=1.1.3=h516909a_0
   - xz=5.2.4=h14c3975_1001
   - yaml=0.2.2=h516909a_1
-  - zipp=2.0.0=py_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h516909a_1006
   - pip:
     - pyqt5-sip==4.19.18

--- a/environment.osx.lock.yml
+++ b/environment.osx.lock.yml
@@ -27,10 +27,10 @@ dependencies:
   - dnaio=0.4.1=py36h01d97ff_0
   - docutils=0.16=py36_0
   - ema=0.6.2=hfbae3c0_1
-  - fastqc=0.11.8=2
+  - fastqc=0.11.9=0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - fontconfig=2.13.1=h6b1039f_1001
-  - freebayes=1.3.3=py36h37cfd92_0
+  - freebayes=1.3.2=py36h37cfd92_0
   - freetype=2.10.0=h24853df_1
   - future=0.18.2=py36_0
   - gatk4=4.1.4.1=1
@@ -42,10 +42,12 @@ dependencies:
   - humanfriendly=4.18=py36_1
   - icu=64.2=h6de7cb9_1
   - idna=2.8=py36_1000
-  - importlib_metadata=1.4.0=py36_0
+  - importlib_metadata=1.5.0=py36_0
   - importlib_resources=1.0.2=py36_1000
+  - inflect=4.0.0=py36_1
   - ipython_genutils=0.2.0=py_1
-  - jinja2=2.10.3=py_0
+  - jaraco.itertools=5.0.0=py_0
+  - jinja2=2.11.0=py_0
   - jsonschema=3.2.0=py36_0
   - jupyter_core=4.6.1=py36_0
   - kiwisolver=1.1.0=py36ha1b3eb9_0
@@ -84,7 +86,7 @@ dependencies:
   - parallel=20200122=0
   - perl=5.26.2=haec8ef5_1006
   - pigz=2.3.4=0
-  - pip=20.0.1=py36_0
+  - pip=20.0.2=py36_0
   - psutil=5.6.7=py36h0b31af3_0
   - pycparser=2.19=py36_1
   - pyopenssl=19.1.0=py36_0
@@ -115,15 +117,15 @@ dependencies:
   - tk=8.6.10=hbbe82c9_0
   - toposort=1.5=py_3
   - tornado=6.0.3=py36h0b31af3_0
-  - tqdm=4.41.1=py_0
+  - tqdm=4.42.0=py_0
   - traitlets=4.3.3=py36_0
   - urllib3=1.25.7=py36_0
   - vcflib=1.0.0_rc2=he0122c3_2
-  - wheel=0.33.6=py36_0
+  - wheel=0.34.1=py36_0
   - wrapt=1.11.2=py36h0b31af3_0
   - xopen=0.8.4=py36_0
   - xz=5.2.4=h1de35cc_1001
   - yaml=0.2.2=h0b31af3_1
-  - zipp=2.0.0=py_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h0b31af3_1006
 

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -57,27 +57,12 @@ rule multiqc_summarize:
         " 2> {log}"
 
 
-rule barcode_sort_fastq:
-    # Assumes barcode read name is followed by barcode sequence.
-    # Exmaple: @ST-E00269:339:H27G2CCX2:7:1102:21186:8060:AAAAAAAATATCTACGCTCA BX:Z:AAAAAAAATATCTACGCTCA
-    output:
-        fastq = "sorted.{nr}.fastq.gz"
-    input:
-        fastq = "trimmed.barcoded.{nr}.fastq.gz"
-    shell:
-        "pigz -cd -p 1 {input.fastq} |"
-        " paste - - - - |"
-        " sort -t ' ' -k2 |"
-        " tr '\t' '\n' |"
-        " pigz > {output.fastq}"
-
-
 rule map_reads:
     output:
         bam = "mapped.sorted.bam"
     input:
-        r1_fastq = "trimmed.barcoded.1.fastq.gz" if config["read_mapper"] != "ema" else "sorted.1.fastq.gz",
-        r2_fastq = "trimmed.barcoded.2.fastq.gz" if config["read_mapper"] != "ema" else "sorted.2.fastq.gz"
+        r1_fastq = "trimmed.barcoded.1.fastq.gz",
+        r2_fastq = "trimmed.barcoded.2.fastq.gz"
     threads: 20
     log: "read_mapping.log"
     run:

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -3,8 +3,14 @@ from snakemake.utils import validate
 configfile: "blr.yaml"
 validate(config, "config.schema.yaml")
 
+# TODO include handling of reads from `longranger basic` that allready have barcodes extracted and trimmed? See issue
+#  in ema when discussed https://github.com/arshajii/ema/issues/15
+
 # Import rules for trimming fastq files.
-include: "rules/trim.smk"
+if config["library_type"] == "blr":
+    include: "rules/trim.smk"
+elif config["library_type"] == "10x":
+    include: "rules/trim_10x.smk"
 
 # Import rules for phasing
 include: "rules/phasing.smk"
@@ -48,24 +54,6 @@ rule multiqc_summarize:
     shell:
         "multiqc"
         " ."
-        " 2> {log}"
-
-
-rule starcode_clustering:
-    # Cluster DBS barcodes using starcode
-    output:
-        "barcodes.clstr"
-    input:
-        "barcodes.fasta.gz"
-    threads: 20
-    log: "starcode_clustering.log"
-    shell:
-        "pigz -cd {input} |"
-        " starcode"
-        " -o {output}"
-        " -t {threads}"
-        " -d {config[barcode_max_dist]}"
-        " --print-clusters"
         " 2> {log}"
 
 

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -3,12 +3,12 @@ from snakemake.utils import validate
 configfile: "blr.yaml"
 validate(config, "config.schema.yaml")
 
-# TODO include handling of reads from `longranger basic` that allready have barcodes extracted and trimmed? See issue
+# TODO include handling of reads from `longranger basic` that already have barcodes extracted and trimmed? See issue
 #  in ema when discussed https://github.com/arshajii/ema/issues/15
 
 # Import rules for trimming fastq files.
 if config["library_type"] == "blr":
-    include: "rules/trim.smk"
+    include: "rules/trim_blr.smk"
 elif config["library_type"] == "10x":
     include: "rules/trim_10x.smk"
 

--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -57,12 +57,27 @@ rule multiqc_summarize:
         " 2> {log}"
 
 
+rule barcode_sort_fastq:
+    # Assumes barcode read name is followed by barcode sequence.
+    # Exmaple: @ST-E00269:339:H27G2CCX2:7:1102:21186:8060:AAAAAAAATATCTACGCTCA BX:Z:AAAAAAAATATCTACGCTCA
+    output:
+        fastq = "sorted.{nr}.fastq.gz"
+    input:
+        fastq = "trimmed.barcoded.{nr}.fastq.gz"
+    shell:
+        "pigz -cd -p 1 {input.fastq} |"
+        " paste - - - - |"
+        " sort -t ' ' -k2 |"
+        " tr '\t' '\n' |"
+        " pigz > {output.fastq}"
+
+
 rule map_reads:
     output:
         bam = "mapped.sorted.bam"
     input:
-        r1_fastq = "trimmed.barcoded.1.fastq.gz",
-        r2_fastq = "trimmed.barcoded.2.fastq.gz"
+        r1_fastq = "trimmed.barcoded.1.fastq.gz" if config["read_mapper"] != "ema" else "sorted.1.fastq.gz",
+        r2_fastq = "trimmed.barcoded.2.fastq.gz" if config["read_mapper"] != "ema" else "sorted.2.fastq.gz"
     threads: 20
     log: "read_mapping.log"
     run:

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -10,14 +10,19 @@ dbSNP: # Path to dbSNP file (common SNP sites)
 BQSR: false # Adjust base calling accuracys using gatk's BQSR (true or false). Recommended if variant_caller is gatk
 read_mapper: bowtie2  # Choose bwa, bowtie2, minimap2 or ema
 duplicate_marker: sambamba # Choose sambamba or samblaster
+library_type: blr # Library type. Chose blr or 10x.
 
 #################
 # Trim settings #
 #################
+# BLR libraries
 h1: CAGTTGATCATCAGCAGGTAATCTGG # h1 adaptor sequnce, appears before barcode in read1
 h2: CATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAG # h2 adaptor sequence, appears after barcode in read1
 h3: CTGTCTCTTATACACATCT # h3 adaptor sequence, appears after genomics insert in read1 and read2.
 barcode_len: 20 # Length of barcode sequence
+
+# 10x libraries
+barcode_whitelist: # Path to barcode whitelist.
 
 ####################
 # Phasing settings #

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -10,7 +10,7 @@ dbSNP: # Path to dbSNP file (common SNP sites)
 BQSR: false # Adjust base calling accuracys using gatk's BQSR (true or false). Recommended if variant_caller is gatk
 read_mapper: bowtie2  # Choose bwa, bowtie2, minimap2 or ema
 duplicate_marker: sambamba # Choose sambamba or samblaster
-library_type: blr # Library type. Chose blr or 10x.
+library_type: # Library type. Chose blr or 10x.
 
 #################
 # Trim settings #
@@ -23,6 +23,7 @@ barcode_len: 20 # Length of barcode sequence
 
 # 10x libraries
 barcode_whitelist: # Path to barcode whitelist.
+apply_hamming_correction: false # Apply hamming correction when demultiplexing 10x barcodes. Increases runtime.
 
 ####################
 # Phasing settings #

--- a/src/blr/cli/config.py
+++ b/src/blr/cli/config.py
@@ -2,14 +2,15 @@
 Update configuration file. If no --set option is given the current settings are printed.
 """
 import sys
-import os
 import logging
 from ruamel.yaml import YAML
 from snakemake.utils import validate
 import pkg_resources
+from pathlib import Path
+from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
-DEFAULT_PATH = "blr.yaml"
+DEFAULT_PATH = Path("blr.yaml")
 SCHEMA_FILE = "config.schema.yaml"
 
 
@@ -25,11 +26,11 @@ def main(args):
         yaml.dump(configs, stream=sys.stdout)
 
 
-def change_config(filename, changes_set):
+def change_config(filename: Path, changes_set: List[Tuple[str, str]]):
     """
     Change config YAML file at filename using the changes_set key-value pairs.
-    :param filename: string with path to YAML config file to change.
-    :param changes_set: dict with changes to incorporate.
+    :param filename: Path to YAML config file to change.
+    :param changes_set: changes to incorporate.
     """
     # Get configs from file.
     configs, yaml = load_yaml(filename)
@@ -48,10 +49,10 @@ def change_config(filename, changes_set):
     validate(configs, schema_path)
 
     # Write first to temporary file then overwrite filename.
-    tmpfile = filename + ".tmp"
+    tmpfile = Path(str(filename) + ".tmp")
     with open(tmpfile, "w") as file:
         yaml.dump(configs, stream=file)
-    os.rename(tmpfile, filename)
+    tmpfile.rename(filename)
 
 
 def load_yaml(filename):
@@ -70,5 +71,5 @@ def add_arguments(parser):
     parser.add_argument("--set", nargs=2, metavar=("KEY", "VALUE"), action="append",
                         help="Set KEY to VALUE. Use KEY.SUBKEY[.SUBSUBKEY...] for nested keys. For empty values "
                              "write 'null'. Can be given multiple times.")
-    parser.add_argument("--file", default=DEFAULT_PATH,
+    parser.add_argument("--file", default=DEFAULT_PATH, type=Path,
                         help="Configuration file to modify. Default: %(default)s in current directory.")

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -73,3 +73,7 @@ properties:
   barcode_whitelist:
     type: [ "string", "null" ]
     description: Path to barcode whitelist for 10x linked-read demultiplexing
+  apply_hamming_correction:
+    type: boolean
+    default: false
+    description: Apply hamming correction when demultiplexing 10x barcodes. Increases runtime.

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -65,4 +65,11 @@ properties:
     pattern: "gatk|bcftools|freebayes|deepvariant"
   heap_space:
     type: integer
-    descriptoin: Heap space to run java scripts with (gatk).
+    description: Heap space to run java scripts with (gatk).
+  library_type:
+    type: string
+    pattern: "blr|10x"
+    description: Library type.
+  barcode_whitelist:
+    type: [ "string", "null" ]
+    description: Path to barcode whitelist for 10x linked-read demultiplexing

--- a/src/blr/rules/trim.smk
+++ b/src/blr/rules/trim.smk
@@ -60,6 +60,7 @@ rule trim_and_tag:
         " -"
         " 2> {log.tag}"
 
+
 rule extract_DBS:
     # Extract barcode sequence from read1 FASTQ
     output:
@@ -80,3 +81,21 @@ rule extract_DBS:
         " -o {output.fastq}"
         " {input.fastq}"
         " > {log}"
+
+
+rule starcode_clustering:
+    # Cluster DBS barcodes using starcode
+    output:
+        "barcodes.clstr"
+    input:
+        "barcodes.fasta.gz"
+    threads: 20
+    log: "starcode_clustering.log"
+    shell:
+        "pigz -cd {input} |"
+        " starcode"
+        " -o {output}"
+        " -t {threads}"
+        " -d {config[barcode_max_dist]}"
+        " --print-clusters"
+        " 2> {log}"

--- a/src/blr/rules/trim_10x.smk
+++ b/src/blr/rules/trim_10x.smk
@@ -1,0 +1,72 @@
+"""
+Rules to process 10xGenomics Chromium linked-read raw FASTQs.
+
+READ1 LAYOUT
+
+5'-NNNNNNNNNNNNNNNN NNNNNNN NNN...NNN-3'
+   <----barcode---> <-UMI-> <-gDNA-->
+         16 nt        7 nt
+
+READ2 LAYOUT
+
+5'-NNNN...NNNN-3'
+   <---gDNA-->
+
+"""
+
+
+rule link_to_whitelist:
+    output: "barcodes_whitelist.txt"
+    shell: "ln -s {config[barcode_whitelist]} {output}"
+
+rule count_10x:
+    output:
+        counts_ncnt = temp("reads.ema-ncnt"),
+        counts_fcnt = temp("reads.ema-fcnt"),
+    input:
+        r1_fastq="reads.1.fastq.gz",
+        r2_fastq="reads.2.fastq.gz",
+        whitelist="barcodes_whitelist.txt"
+    log: "ema_count.log"
+    shell:
+        "paste <(pigz -c -d {input.r1_fastq} | paste - - - -) <(pigz -c -d {input.r2_fastq} | paste - - - -) |"
+        " tr '\t' '\n' |"
+        " ema count"
+        " -w {input.whitelist}"
+        " -o reads 2> {log}"
+
+rule preproc_10x:
+    output:
+        bins = temp(directory("temp_bins"))
+    input:
+        r1_fastq="reads.1.fastq.gz",
+        r2_fastq="reads.2.fastq.gz",
+        counts_ncnt = "reads.ema-ncnt",
+        counts_fcnt = "reads.ema-fcnt",
+        whitelist = "barcodes_whitelist.txt"
+    log: "ema_preproc.log"
+    threads: 20
+    shell:
+        "paste <(pigz -c -d {input.r1_fastq} | paste - - - -) <(pigz -c -d {input.r2_fastq} | paste - - - -) |"
+        " tr '\t' '\n' |"
+        " ema preproc"
+        " -w {input.whitelist}"
+        " -n {threads}"
+        " -t {threads}"
+        " -b"
+        " -h"
+        " -o {output.bins} {input.counts_ncnt} 2>&1 | tee {log}"
+
+rule merge_bins_and_split_pairs:
+    output:
+        r1_fastq="trimmed.barcoded.1.fastq.gz",
+        r2_fastq="trimmed.barcoded.2.fastq.gz",
+
+    input:
+        bins = "temp_bins"
+    shell:
+        "cat {input.bins}/ema-bin* |"
+        " paste - - - - - - - - |"
+        " tee >(cut -f 1-4 | tr '\t' '\n' | pigz -c > {output.r1_fastq}) |"
+        " cut -f 5-8 | tr '\t' '\n' | pigz -c > {output.r2_fastq}"
+

--- a/src/blr/rules/trim_10x.smk
+++ b/src/blr/rules/trim_10x.smk
@@ -12,6 +12,8 @@ READ2 LAYOUT
 5'-NNNN...NNNN-3'
    <---gDNA-->
 
+Processing is partly based on the 10x end-to-end workflow described for the EMA aligner. See the docs on their github
+https://github.com/arshajii/ema#end-to-end-workflow-10x
 """
 
 
@@ -20,9 +22,10 @@ rule link_to_whitelist:
     shell: "ln -s {config[barcode_whitelist]} {output}"
 
 rule count_10x:
+    "Create list of per-barcode count"
     output:
         counts_ncnt = temp("reads.ema-ncnt"),
-        counts_fcnt = temp("reads.ema-fcnt"),
+        counts_fcnt = temp("reads.ema-fcnt")
     input:
         r1_fastq="reads.1.fastq.gz",
         r2_fastq="reads.2.fastq.gz",
@@ -36,8 +39,9 @@ rule count_10x:
         " -o reads 2> {log}"
 
 rule preproc_10x:
+    "Trim reads and bin reads containing the same barcode together. Reads missing barcodes outputed to ema-nobc."
     output:
-        bins = temp(directory("temp_bins"))
+        bins = directory("temp_bins")
     input:
         r1_fastq="reads.1.fastq.gz",
         r2_fastq="reads.2.fastq.gz",
@@ -46,22 +50,26 @@ rule preproc_10x:
         whitelist = "barcodes_whitelist.txt"
     log: "ema_preproc.log"
     threads: 20
-    shell:
-        "paste <(pigz -c -d {input.r1_fastq} | paste - - - -) <(pigz -c -d {input.r2_fastq} | paste - - - -) |"
-        " tr '\t' '\n' |"
-        " ema preproc"
-        " -w {input.whitelist}"
-        " -n {threads}"
-        " -t {threads}"
-        " -b"
-        " -h"
-        " -o {output.bins} {input.counts_ncnt} 2>&1 | tee {log}"
+    run:
+        hamming_correction = "" if not config["apply_hamming_correction"] else " -h"
+        shell(
+            "paste <(pigz -c -d {input.r1_fastq} | paste - - - -) <(pigz -c -d {input.r2_fastq} | paste - - - -) |"
+            " tr '\t' '\n' |"
+            " ema preproc"
+            " -w {input.whitelist}"
+            " -n {threads}"
+            "{hamming_correction}"
+            " -t {threads}"
+            " -b"
+            " -h"
+            " -o {output.bins} {input.counts_ncnt} 2>&1 | tee {log}"
+        )
 
 rule merge_bins_and_split_pairs:
+    "Merge bins of trimmed and barcoded reads together and split into read pairs."
     output:
         r1_fastq="trimmed.barcoded.1.fastq.gz",
-        r2_fastq="trimmed.barcoded.2.fastq.gz",
-
+        r2_fastq="trimmed.barcoded.2.fastq.gz"
     input:
         bins = "temp_bins"
     shell:
@@ -70,3 +78,14 @@ rule merge_bins_and_split_pairs:
         " tee >(cut -f 1-4 | tr '\t' '\n' | pigz -c > {output.r1_fastq}) |"
         " cut -f 5-8 | tr '\t' '\n' | pigz -c > {output.r2_fastq}"
 
+rule split_nobc_reads:
+    "Split non-barcoded reads into read pairs."
+    output:
+        r1_fastq="trimmed.non_barcoded.1.fastq.gz",
+        r2_fastq="trimmed.non_barcoded.2.fastq.gz",
+    input:
+        fastq = "temp_bins/ema-nobc"
+    shell:
+        " paste - - - - - - - - < {input} |"
+        " tee >(cut -f 1-4 | tr '\t' '\n' | pigz -c > {output.r1_fastq}) |"
+        " cut -f 5-8 | tr '\t' '\n' | pigz -c > {output.r2_fastq}"

--- a/src/blr/rules/trim_blr.smk
+++ b/src/blr/rules/trim_blr.smk
@@ -1,20 +1,20 @@
 """
-Rules connected to trimming of FASTQ files.
+Rules for trimming and demultiplexing of raw BLR FASTQ files.
 
 READ1 LAYOUT
 
-5'-CAGTTGATCATCAGCAGGTAATCTGGBDVHBDVHBDVHBDVHBDVHCATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAGNNNN...NNNN(CTGTCTCTTATACACATCT)-3'
-   <------------h1----------><-------DBS--------><-----------------h2------------------><---gDNA--><---------h3-------->
-    h1 may inlude frameshift                                                                        Presence depencd on
-    oligos varying from 0-4                                                                         insert length
+5'-CAGTTGATCATCAGCAGGTAATCTGG BDVHBDVHBDVHBDVHBDVH CATGACCTCTTGGAACTGTCAGATGTGTATAAGAGACAG NNNN...NNNN (CTGTCTCTTATACACATCT)-3'
+   <------------h1----------> <-------DBS--------> <-----------------h2------------------> <---gDNA--> <---------h3-------->
+    h1 may inlude frameshift                                                                           Presence depends on
+    oligos varying from 0-4                                                                            insert length
     extra oligos in 5' end
 
 READ 2 LAYOUT
 
-5'-NNNN...NNNN(CTGTCTCTTATACACATCT)-3'
-   <---gDNA--><---------h3-------->
-              Presence depencd on
-              insert length
+5'-NNNN...NNNN (CTGTCTCTTATACACATCT)-3'
+   <---gDNA--> <---------h3-------->
+               Presence depends on
+               insert length
 """
 
 DBS = "N"*config["barcode_len"]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,8 +19,9 @@ if test ! -f testdata/chr1mini.dict; then ( cd testdata && gatk CreateSequenceDi
 
 pytest -v tests/
 
+# Test full run on BLR library.
 rm -rf outdir-bowtie2
-blr init --r1=testdata/reads.1.fastq.gz outdir-bowtie2
+blr init --r1=testdata/blr_reads.1.fastq.gz outdir-bowtie2
 blr config \
     --file outdir-bowtie2/blr.yaml \
     --set genome_reference ../testdata/chr1mini.fasta \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,7 +21,7 @@ pytest -v tests/
 
 # Test full run on BLR library.
 rm -rf outdir-bowtie2
-blr init --r1=testdata/blr_reads.1.fastq.gz outdir-bowtie2
+blr init --r1=testdata/blr_reads.1.fastq.gz -l blr outdir-bowtie2
 blr config \
     --file outdir-bowtie2/blr.yaml \
     --set genome_reference ../testdata/chr1mini.fasta \

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,12 +34,12 @@ def count_fastq_reads(path):
 
 
 def test_init(tmpdir):
-    init(tmpdir / "analysis", TESTDATA_READS)
+    init(tmpdir / "analysis", TESTDATA_READS, "blr")
 
 
 def test_config(tmpdir):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(workdir / "blr.yaml", [("read_mapper", "bwa")])
 
 # TODO add trim test for blr reads.
@@ -47,11 +47,10 @@ def test_config(tmpdir):
 
 def test_trim_tenx(tmpdir):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_TENX_READ1)
+    init(workdir, TESTDATA_TENX_READ1, "10x")
     change_config(
         workdir / DEFAULT_CONFIG,
-        [("library_type", "10x"),
-         ("barcode_whitelist", TESTDATA_TENX_BARCODES)]
+        [("barcode_whitelist", TESTDATA_TENX_BARCODES)]
     )
     trimmed = ["trimmed.barcoded.1.fastq.gz", "trimmed.barcoded.2.fastq.gz"]
     run(workdir=workdir, targets=trimmed)
@@ -62,7 +61,7 @@ def test_trim_tenx(tmpdir):
 @pytest.mark.parametrize("read_mapper", ["bwa", "bowtie2", "minimap2", "ema"])
 def test_mappers(tmpdir, read_mapper):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME), ("read_mapper", read_mapper)]
@@ -75,7 +74,7 @@ def test_mappers(tmpdir, read_mapper):
 @pytest.mark.parametrize("duplicate_marker", ["sambamba", "samblaster"])
 def test_duplicate_markers(tmpdir, duplicate_marker):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME), ("duplicate_marker", duplicate_marker)]
@@ -87,7 +86,7 @@ def test_duplicate_markers(tmpdir, duplicate_marker):
 
 def test_final_compressed_reads_exist(tmpdir):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME)]
@@ -100,7 +99,7 @@ def test_final_compressed_reads_exist(tmpdir):
 
 def test_link_reference_variants(tmpdir):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME), ("reference_variants", REFERENCE_VARIANTS)]
@@ -112,7 +111,7 @@ def test_link_reference_variants(tmpdir):
 
 def test_BQSR(tmpdir):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME), ("dbSNP", DB_SNP), ("BQSR", "true"), ("reference_variants", "null"),
@@ -126,7 +125,7 @@ def test_BQSR(tmpdir):
 @pytest.mark.parametrize("variant_caller", ["freebayes", "bcftools", "gatk"])
 def test_call_variants(tmpdir, variant_caller):
     workdir = tmpdir / "analysis"
-    init(workdir, TESTDATA_READS)
+    init(workdir, TESTDATA_READS, "blr")
     change_config(
         workdir / DEFAULT_CONFIG,
         [("genome_reference", REFERENCE_GENOME), ("reference_variants", "null"), ("variant_caller", variant_caller)]


### PR DESCRIPTION
Integrated processing and demultiplexing of raw reads from 10x Chromium runs. I used the preprocessing tools from  the `ema` package which includes a [end-to-end workflow](https://github.com/arshajii/ema#end-to-end-workflow-10x). The current testdata was generated using [LRTK-SIM](https://github.com/zhanglu295/LRTK-SIM), a linked-read simulator. I will update this later on with a real subset for testing. 

The new processing step are contained within the `trim_10.smk` script. I also moved the `starcode_clustering` rule from the main Snakemake script to the `trim.smk` script for 'blr' type reads to contain all rules unique to one library type within each. 